### PR TITLE
Dockerize and run download-UI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV XDG_CACHE_HOME="$HOME/.cache"
 
 RUN install -d -o "$UID" -g "$GID" "$HOME"
 
-USER "$UID:$GID"
+USER "$BUILD_ID"
 
 WORKDIR "$HOME"
 
@@ -23,7 +23,6 @@ ENV npm_config_cache="$XDG_CACHE_HOME/npm" \
 ENV NEXT_TELEMETRY_DISABLED=1
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-
 CMD ["./docker-entrypoint.sh"]
 
 # ----
@@ -69,18 +68,18 @@ ENV HOME=/app
 
 RUN install -d -o "$UID" -g "$GID" "$HOME"
 
-USER "$UID:$GID"
+USER "$BUILD_ID"
 
-ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
+ENV NODE_ENV=production
 ENV SERVICE_MODE=production
 
 WORKDIR "$HOME"
 
 # Copy standalone server output
-COPY --from=prod-build --chown="$UID:$GID" "$HOME/.next/standalone" ./
-COPY --from=prod-build --chown="$UID:$GID" "$HOME/.next/static" ./.next/static
-COPY --chown="$UID:$GID" docker-entrypoint.sh .
+COPY --from=prod-build --chown="$BUILD_ID" "$HOME/.next/standalone" ./
+COPY --from=prod-build --chown="$BUILD_ID" "$HOME/.next/static" ./.next/static
+COPY --chown="$BUILD_ID" --chmod=755 docker-entrypoint.sh .
 
 USER "$RUNTIME_ID"
 
@@ -100,8 +99,8 @@ ENV NEXT_PUBLIC_BUILD_DATE="$BUILD_DATE" \
     NEXT_PUBLIC_BUILD_GIT_COMMIT="$BUILD_GIT_COMMIT" \
     NEXT_PUBLIC_BUILD_GIT_BRANCH="$BUILD_GIT_BRANCH"
 
-ENV SERVICE_MODE=development
-
+ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=development
+ENV SERVICE_MODE=development
 
 USER "$RUNTIME_ID"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-alpine AS base
+FROM node:lts-alpine AS base
 
 ARG BUILD_ID=1000:1000
 ARG RUNTIME_ID=1000:1000
@@ -55,7 +55,7 @@ RUN --mount=type=cache,id=npm-cache,uid="$UID",target="$npm_config_cache" \
 # ----
 
 ## Production stage
-FROM node:24-alpine AS prod
+FROM node:lts-alpine AS prod
 
 ARG BUILD_ID=1000:1000
 ARG RUNTIME_ID=1000:1000
@@ -105,4 +105,3 @@ ENV SERVICE_MODE=development
 ENV NODE_ENV=development
 
 USER "$RUNTIME_ID"
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,108 @@
+FROM node:24-alpine AS base
+
+ARG BUILD_ID=1000:1000
+ARG RUNTIME_ID=1000:1000
+ARG UID=${BUILD_ID%:*}
+ARG GID=${BUILD_ID#*:}
+
+RUN --mount=type=cache,id=apk-cache,target=/var/cache/apk \
+	apk --cache-dir=/var/cache/apk add \
+		dumb-init
+
+ENV HOME=/app
+ENV XDG_CACHE_HOME="$HOME/.cache"
+
+RUN install -d -o "$UID" -g "$GID" "$HOME"
+
+USER "$UID:$GID"
+
+WORKDIR "$HOME"
+
+ENV npm_config_cache="$XDG_CACHE_HOME/npm" \
+    npm_config_loglevel=info
+ENV NEXT_TELEMETRY_DISABLED=1
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+
+CMD ["./docker-entrypoint.sh"]
+
+# ----
+
+## Production build stage
+FROM base AS prod-build
+
+RUN --mount=type=bind,source=package.json,target=./package.json,readonly \
+    --mount=type=bind,source=package-lock.json,target=./package-lock.json,readonly \
+    --mount=type=cache,id=npm-cache,uid="$UID",target="$npm_config_cache" \
+	npm ci
+
+COPY --chown="$UID:$GID" package*.json .
+COPY --chown="$UID:$GID" ./tsconfig.json .
+COPY --chown="$UID:$GID" ./next*.ts .
+COPY --chown="$UID:$GID" ./src ./src
+
+ARG BUILD_GIT_COMMIT
+ARG BUILD_GIT_BRANCH
+
+ENV NEXT_PUBLIC_BUILD_GIT_COMMIT="$BUILD_GIT_COMMIT" \
+    NEXT_PUBLIC_BUILD_GIT_BRANCH="$BUILD_GIT_BRANCH"
+
+RUN mkdir -p .next/cache
+RUN --mount=type=cache,id=npm-cache,uid="$UID",target="$npm_config_cache" \
+    --mount=type=cache,id=next-cache,uid="$UID",target=.next/cache \
+	npm run build
+
+# ----
+
+## Production stage
+FROM node:24-alpine AS prod
+
+ARG BUILD_ID=1000:1000
+ARG RUNTIME_ID=1000:1000
+ARG UID=${BUILD_ID%:*}
+ARG GID=${BUILD_ID#*:}
+
+RUN --mount=type=cache,id=apk-cache,target=/var/cache/apk \
+	apk --cache-dir=/var/cache/apk add dumb-init
+
+ENV HOME=/app
+
+RUN install -d -o "$UID" -g "$GID" "$HOME"
+
+USER "$UID:$GID"
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV SERVICE_MODE=production
+
+WORKDIR "$HOME"
+
+# Copy standalone server output
+COPY --from=prod-build --chown="$UID:$GID" "$HOME/.next/standalone" ./
+COPY --from=prod-build --chown="$UID:$GID" "$HOME/.next/static" ./.next/static
+COPY --chown="$UID:$GID" docker-entrypoint.sh .
+
+USER "$RUNTIME_ID"
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["./docker-entrypoint.sh"]
+
+# ----
+
+## Development stage
+FROM base AS dev
+
+ARG BUILD_DATE
+ARG BUILD_GIT_COMMIT
+ARG BUILD_GIT_BRANCH
+
+ENV NEXT_PUBLIC_BUILD_DATE="$BUILD_DATE" \
+    NEXT_PUBLIC_BUILD_GIT_COMMIT="$BUILD_GIT_COMMIT" \
+    NEXT_PUBLIC_BUILD_GIT_BRANCH="$BUILD_GIT_BRANCH"
+
+ENV SERVICE_MODE=development
+
+ENV NODE_ENV=development
+
+USER "$RUNTIME_ID"
+

--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ To build only (no run):
 
 ### Connectivity to the sda dev stack
 
-The `sda-download-UI` containers can access services of the sda-stack throught calls to localhost, e.g. fetching a token array from `http://localhost:8001/tokens` should work.
+The `sda-download-UI` containers can access services of the sda-stack through calls to the host gateway, e.g. fetching a token array from `http://host.docker.internal:8001/tokens` should work.

--- a/README.md
+++ b/README.md
@@ -4,19 +4,29 @@ Repository containing the UI implementation of the sda-download service
 
 ## Development
 
-The local development environment for the `sda-download UI` can be deployed using docker compose files from this repository. The environment consists of a compose file for starting a minimal sda development stack and the compose file for deploying the download UI webapp.
+The local development environment for the `sda-download UI` can be
+deployed using docker compose files from this repository. The
+environment consists of a compose file for starting a minimal sda
+development stack and the compose file for deploying the download UI
+webapp.
 
 ### SDA development stack
 
-The necessary configuration and compose files for starting the development stack for the `sda` backend services can be found under `./dev-tools`. The stack includes the `sda-download` API service, OIDC services and any required dependencies. Details for the stack and instructions on how to run and test it can be found in the [README file](dev-tools/README.md) of that folder.
+The necessary configuration and compose files for starting the
+development stack for the `sda` backend services can be found under
+`./dev-tools`. The stack includes the `sda-download` API service, OIDC
+services and any required dependencies. Details for the stack and
+instructions on how to run and test it can be found in the [README
+file](dev-tools/README.md) of that folder.
 
 ### Download UI development stack
 
-```sh
+``` sh
 ./compose-dev.sh up --build
 ```
 
-This mounts `./frontend` into the container, installs dependencies (if needed), and runs `next dev`.
+This mounts `./frontend` into the container, installs dependencies (if
+needed), and runs `next dev`.
 
 Open the UI at:
 
@@ -24,11 +34,12 @@ Open the UI at:
 
 Notes:
 
-- On first run the container will run `npm ci` and create `frontend/node_modules/` on your host (Linux recommended).
+- On first run the container will run `npm ci` and create
+  `frontend/node_modules/` on your host (Linux recommended).
 
 Stop and remove containers:
 
-```sh
+``` sh
 ./compose-dev.sh down
 ```
 
@@ -36,7 +47,7 @@ Stop and remove containers:
 
 Build and run the production image using the `compose-prod.sh` :
 
-```sh
+``` sh
 ./compose-prod.sh up --build
 ```
 
@@ -44,7 +55,8 @@ Open the UI at:
 
 - http://localhost:3002
 
-This mode is intended to be close to Kubernetes “PSA (Pod Security Admission) restricted” operation:
+This mode is intended to be close to Kubernetes "PSA (Pod Security
+Admission) restricted" operation:
 
 - runs as a non-root UID/GID (`6001:6001`)
 - no-new-privileges
@@ -54,16 +66,18 @@ This mode is intended to be close to Kubernetes “PSA (Pod Security Admission) 
 
 Stop and remove containers:
 
-```sh
+``` sh
 ./compose-prod.sh down
 ```
 
 To build only (no run):
 
-```sh
+``` sh
 ./compose-prod.sh build
 ```
 
 ### Connectivity to the sda dev stack
 
-The `sda-download-UI` containers can access services of the sda-stack through calls to the host gateway, e.g. fetching a token array from `http://host.docker.internal:8001/tokens` should work.
+The `sda-download-UI` containers can access services of the sda-stack
+through calls to the host gateway, e.g. fetching a token array from
+`http://host.docker.internal:8001/tokens` should work.

--- a/README.md
+++ b/README.md
@@ -12,15 +12,6 @@ The necessary configuration and compose files for starting the development stack
 
 ### Download UI development stack
 
-The `./docker-compose.yml` provides two Docker Compose profiles:
-
-- `dev`: run the Next.js app in development mode with local files mounted for live editing.
-- `prod`: build and run a production-grade image (Next.js standalone output)
-
-These can be used via the scripts `compose-dev.sh` and `compose-prod.sh`.
-
-Build and run the development image using the `dev` profile:
-
 ```sh
 ./compose-dev.sh up --build
 ```
@@ -43,7 +34,7 @@ Stop and remove containers:
 
 ### Download UI production-like build and local run
 
-Build and run the production image using the `prod` profile:
+Build and run the production image using the `compose-prod.sh` :
 
 ```sh
 ./compose-prod.sh up --build

--- a/README.md
+++ b/README.md
@@ -12,4 +12,63 @@ The necessary configuration and compose files for starting the development stack
 
 ### Download UI development stack
 
-TBD
+The `./docker-compose.yml` provides two Docker Compose profiles:
+
+- `dev`: run the Next.js app in development mode with local files mounted for live editing.
+- `prod`: build and run a production-grade image (Next.js standalone output)
+
+These can be used via the scripts `compose-dev.sh` and `compose-prod.sh`.
+
+Build and run the development image using the `dev` profile:
+
+```sh
+./compose-dev.sh up --build
+```
+
+This mounts `./frontend` into the container, installs dependencies (if needed), and runs `next dev`.
+
+Open the UI at:
+
+- http://localhost:3002
+
+Notes:
+
+- On first run the container will run `npm ci` and create `frontend/node_modules/` on your host (Linux recommended).
+
+Stop and remove containers:
+
+```sh
+./compose-dev.sh down
+```
+
+### Download UI production-like build and local run
+
+Build and run the production image using the `prod` profile:
+
+```sh
+./compose-prod.sh up --build
+```
+
+Open the UI at:
+
+- http://localhost:3002
+
+This mode is intended to be close to Kubernetes “PSA (Pod Security Admission) restricted” operation:
+
+- runs as a non-root UID/GID (`6001:6001`)
+- no-new-privileges
+- drops all Linux capabilities
+- read-only root filesystem
+- writable `/tmp` via tmpfs
+
+Stop and remove containers:
+
+```sh
+./compose-prod.sh down
+```
+
+## Build only (no run)
+
+```sh
+./compose-prod.sh build
+```

--- a/README.md
+++ b/README.md
@@ -67,8 +67,12 @@ Stop and remove containers:
 ./compose-prod.sh down
 ```
 
-## Build only (no run)
+To build only (no run):
 
 ```sh
 ./compose-prod.sh build
 ```
+
+### Connectivity to the sda dev stack
+
+The `sda-download-UI` containers can access services of the sda-stack throught calls to localhost, e.g. fetching a token array from `http://localhost:8001/tokens` should work.

--- a/compose-dev.sh
+++ b/compose-dev.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -
 
+set -u
+
 # In development, the build and runtime user:group is the same as the
 # host's user:group, so that files created by the container are owned by
 # the host user.
@@ -8,6 +10,5 @@ uid="$(id -u)"
 gid="$(id -g)"
 export BUILD_ID="${BUILD_ID:-"$uid:$gid"}"
 export RUNTIME_ID="${RUNTIME_ID:-"$uid:$gid"}"
-export SERVICE_MODE=dev
 
-exec docker compose -f docker-compose.yml --profile dev "$@"
+exec "$(dirname "$0")/compose-prod.sh" -f docker-compose.dev.yml "$@"

--- a/compose-dev.sh
+++ b/compose-dev.sh
@@ -1,0 +1,13 @@
+#!/bin/sh -
+
+# In development, the build and runtime user:group is the same as the
+# host's user:group, so that files created by the container are owned by
+# the host user.
+
+uid="$(id -u)"
+gid="$(id -g)"
+export BUILD_ID="${BUILD_ID:-"$uid:$gid"}"
+export RUNTIME_ID="${RUNTIME_ID:-"$uid:$gid"}"
+export SERVICE_MODE=dev
+
+exec docker compose -f docker-compose.yml --profile dev "$@"

--- a/compose-prod.sh
+++ b/compose-prod.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -
 
+set -u
+
 # Unless already set, the build and runtime user:group IDs default to
 # 6000:6000 and 6001:6001, respectively.
 export BUILD_ID="${BUILD_ID:-6000:6000}"
@@ -10,4 +12,4 @@ export TAG="${TAG:-latest}"
 export BUILD_GIT_COMMIT="$(git rev-parse --short HEAD 2>/dev/null || true)"
 export BUILD_GIT_BRANCH="$(git symbolic-ref --short -q HEAD 2>/dev/null || true)"
 
-exec docker compose -f docker-compose.yml --profile prod "$@"
+exec docker compose -f docker-compose.yml "$@"

--- a/compose-prod.sh
+++ b/compose-prod.sh
@@ -1,0 +1,13 @@
+#!/bin/sh -
+
+# Unless already set, the build and runtime user:group IDs default to
+# 6000:6000 and 6001:6001, respectively.
+export BUILD_ID="${BUILD_ID:-6000:6000}"
+export RUNTIME_ID="${RUNTIME_ID:-6001:6001}"
+export TAG="${TAG:-latest}"
+
+# Set environment variables for build info.
+export BUILD_GIT_COMMIT="$(git rev-parse --short HEAD 2>/dev/null || true)"
+export BUILD_GIT_BRANCH="$(git symbolic-ref --short -q HEAD 2>/dev/null || true)"
+
+exec docker compose -f docker-compose.yml --profile prod "$@"

--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -1,31 +1,46 @@
 # Download API v2 - Local Development
 
-Dev stack for building applications against the sda-download v2 API. It includes, `sda-download`, `sda-auth`, `ls-aai-mock`, their dependencies and scripts to populate the database and the s3 inbox with mock data for testing. This is a modified version of the stack from [this](https://github.com/neicnordic/sensitive-data-archive/pull/2368) PR.
+Dev stack for building applications against the sda-download v2 API. It
+includes, `sda-download`, `sda-auth`, `ls-aai-mock`, their dependencies
+and scripts to populate the database and the s3 inbox with mock data for
+testing. This is a modified version of the stack from
+[this](https://github.com/neicnordic/sensitive-data-archive/pull/2368)
+PR.
 
 There are two mock services included for issuing tokens:
 
-- The `mockauth` is a python script that serves tokens directly from a `/token` endpoint. These work with the dataset initialized by `seed.sh`. This is great for developing all website functionality except the login flow that involves `sda-auth`.
+- The `mockauth` is a python script that serves tokens directly from a
+  `/token` endpoint. These work with the dataset initialized by
+  `seed.sh`. This is great for developing all website functionality
+  except the login flow that involves `sda-auth`.
 
-- The `sda-auth` and `ls-aai-mock` stack included here is the more realistic mock that mirrors closely what is used in production to fetch tokens. This can be used for [developing the login flow of the website](https://github.com/neicnordic/sensitive-data-archive/blob/example/use-sda-auth-for-download-webapp/sda/cmd/auth/auth2webapp.md) once the necessary modifications in `sda-auth` are merged in the sda repository. The website will ultimately work with this stack.
+- The `sda-auth` and `ls-aai-mock` stack included here is the more
+  realistic mock that mirrors closely what is used in production to
+  fetch tokens. This can be used for [developing the login flow of the
+  website](https://github.com/neicnordic/sensitive-data-archive/blob/example/use-sda-auth-for-download-webapp/sda/cmd/auth/auth2webapp.md)
+  once the necessary modifications in `sda-auth` are merged in the sda
+  repository. The website will ultimately work with this stack.
 
-Both mock oidc services above will serve tokens that work with `sda-download-v2` but at the moment only the `mockauth` token contains visas that grand access to the test dataset.
+Both mock oidc services above will serve tokens that work with
+`sda-download-v2` but at the moment only the `mockauth` token contains
+visas that grand access to the test dataset.
 
 ## Quick Start
 
 Create a fresh `config.yaml` instance:
 
-```bash
+``` bash
 cp config.yaml.example config.yaml
 ```
 
 ### With `mockauth` only
 
-```bash
+``` bash
 # Start all services
 docker compose -f sda-dev-stack.yml up -d
 ```
 
-```bash
+``` bash
 # Get a token
 TOKEN=$(curl -s http://localhost:8001/tokens | jq -r '.[0]')
 
@@ -38,9 +53,11 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:8085/datasets/EGAD000000
 
 ### With `sda-auth` and `ls-aai-mock`
 
-To save on resources, the `sda-auth` stack is not started by default but activated as a profile. In order to do so, first uncomment the following line from `config.yaml`:
+To save on resources, the `sda-auth` stack is not started by default but
+activated as a profile. In order to do so, first uncomment the following
+line from `config.yaml`:
 
-```yaml
+``` yaml
 jwt:
   pubkey-path: "/shared/keys/pub/"
   # pubkey-url: "http://localhost:8800/oidc/jwk"
@@ -49,39 +66,47 @@ jwt:
 
 and then change
 
-```yaml
+``` yaml
 userinfo-url: "http://mockauth:8000/userinfo"
 ```
 
 to
 
-```yaml
+``` yaml
 userinfo-url: "http://localhost:8800/oidc/userinfo"
 ```
 
 Finally run:
 
-```bash
+``` bash
 docker compose -f sda-dev-stack.yml --profile sda-auth up -d
 ```
 
 ## Services
 
-| Service  | Port  | Description                                         |
-|----------|-------|-----------------------------------------------------|
-| download | 8085  | Download API v2                                     |
-| mockauth | 8001  | Mock OIDC (JWKS, userinfo, /tokens)                 |
-| postgres | 15432 | PostgreSQL with SDA schema                          |
-| minio    | 19000 | S3 storage (console at 19001)                       |
-| reencrypt| 50051 | gRPC re-encryption for file downloads               |
-| auth-aai | 8801  | OpenIDConnect client for fetching tokens            |
-| mock-aai | 8800  | Mock LS-AAI OIDC server for issuing tokens and visas|
+  -------------------------------------------------------------------------
+  Service     Port    Description
+  ----------- ------- -----------------------------------------------------
+  download    8085    Download API v2
+
+  mockauth    8001    Mock OIDC (JWKS, userinfo, /tokens)
+
+  postgres    15432   PostgreSQL with SDA schema
+
+  minio       19000   S3 storage (console at 19001)
+
+  reencrypt   50051   gRPC re-encryption for file downloads
+
+  auth-aai    8801    OpenIDConnect client for fetching tokens
+
+  mock-aai    8800    Mock LS-AAI OIDC server for issuing tokens and visas
+  -------------------------------------------------------------------------
 
 ## Getting Tokens
 
 ### With mockauth
 
-```bash
+``` bash
 # Token for integration_test@example.org (has access to all test datasets)
 TOKEN=$(curl -s http://localhost:8001/tokens | jq -r '.[0]')
 ```
@@ -90,19 +115,26 @@ TOKEN=$(curl -s http://localhost:8001/tokens | jq -r '.[0]')
 
 Manual flow:
 
-Go to `http://localhost:8801` and follow the login flow, copy the second token (the one for download) on the final page and paste it in a file. Then `token=$(cat <filename>)` and use it the same way as described above.
+Go to `http://localhost:8801` and follow the login flow, copy the second
+token (the one for download) on the final page and paste it in a file.
+Then `token=$(cat <filename>)` and use it the same way as described
+above.
 
-Note: since the token issued from `sda-auth`/`ls-aai-mock` contains no granted visas for accessing the test dataset, if this token is used in the examples of this document the expected response is an empty list.
+Note: since the token issued from `sda-auth`/`ls-aai-mock` contains no
+granted visas for accessing the test dataset, if this token is used in
+the examples of this document the expected response is an empty list.
 
 Code handoff flow:
 
-Description to be added when an `sda-auth` image with the feature implemented is available.
+Description to be added when an `sda-auth` image with the feature
+implemented is available.
 
 ## API Endpoints
 
-Full documentation: [sda/cmd/download/download.md](../../sda/cmd/download/download.md)
+Full documentation:
+[sda/cmd/download/download.md](../../sda/cmd/download/download.md)
 
-```bash
+``` bash
 # Health check
 curl http://localhost:8085/health/ready
 
@@ -141,27 +173,32 @@ curl -H "Authorization: Bearer $TOKEN" \
 The stack is pre-seeded with:
 
 - **Dataset**: `EGAD00000000001` ("Test Dataset")
-- **File**: `EGAF00000000001` (`test-file.c4gh`, 1000 bytes archived, 500 bytes decrypted)
+- **File**: `EGAF00000000001` (`test-file.c4gh`, 1000 bytes archived,
+  500 bytes decrypted)
 - **User**: `integration_test@example.org` (file owner)
 
 ## Cleanup
 
-```bash
+``` bash
 docker compose -f sda-dev-stack.yml down
 ```
 
 or
 
-```bash
+``` bash
 docker compose -f sda-dev-stack.yml --profile sda-auth down
 ```
 
 ## Versioning
 
-By default the deployed sda stack version is set to the latest stable at the time of writing. It is possible to change the stack version by setting the image `TAG` variable as follows:
+By default the deployed sda stack version is set to the latest stable at
+the time of writing. It is possible to change the stack version by
+setting the image `TAG` variable as follows:
 
-```bash
+``` bash
 TAG=PR2026-03-30 docker compose -f sda-dev-stack.yml up
 ```
 
-Note that the [sensitive data archive repository](https://github.com/neicnordic/sensitive-data-archive) builds new images whenever a new PR is merged or opened.
+Note that the [sensitive data archive
+repository](https://github.com/neicnordic/sensitive-data-archive) builds
+new images whenever a new PR is merged or opened.

--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -23,7 +23,7 @@ There are two mock services included for issuing tokens:
 
 Both mock oidc services above will serve tokens that work with
 `sda-download-v2` but at the moment only the `mockauth` token contains
-visas that grand access to the test dataset.
+visas that grant access to the test dataset.
 
 ## Quick Start
 

--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -84,23 +84,15 @@ docker compose -f sda-dev-stack.yml --profile sda-auth up -d
 
 ## Services
 
-  -------------------------------------------------------------------------
-  Service     Port    Description
-  ----------- ------- -----------------------------------------------------
-  download    8085    Download API v2
-
-  mockauth    8001    Mock OIDC (JWKS, userinfo, /tokens)
-
-  postgres    15432   PostgreSQL with SDA schema
-
-  minio       19000   S3 storage (console at 19001)
-
-  reencrypt   50051   gRPC re-encryption for file downloads
-
-  auth-aai    8801    OpenIDConnect client for fetching tokens
-
-  mock-aai    8800    Mock LS-AAI OIDC server for issuing tokens and visas
-  -------------------------------------------------------------------------
+| Service   | Port  | Description                                          |
+|-----------|-------|------------------------------------------------------|
+| download  | 8085  | Download API v2                                      |
+| mockauth  | 8001  | Mock OIDC (JWKS, userinfo, /tokens)                  |
+| postgres  | 15432 | PostgreSQL with SDA schema                           |
+| minio     | 19000 | S3 storage (console at 19001)                        |
+| reencrypt | 50051 | gRPC re-encryption for file downloads                |
+| auth-aai  | 8801  | OpenIDConnect client for fetching tokens             |
+| mock-aai  | 8800  | Mock LS-AAI OIDC server for issuing tokens and visas |
 
 ## Getting Tokens
 
@@ -172,7 +164,7 @@ curl -H "Authorization: Bearer $TOKEN" \
 
 The stack is pre-seeded with:
 
-- **Dataset**: `EGAD00000000001` ("Test Dataset")
+- **Dataset**: `EGAD00000000001` (“Test Dataset”)
 - **File**: `EGAF00000000001` (`test-file.c4gh`, 1000 bytes archived,
   500 bytes decrypted)
 - **User**: `integration_test@example.org` (file owner)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,10 @@
+name: sda-download-ui
+
+services:
+
+  frontend:
+    build:
+      target: dev
+    read_only: false
+    volumes:
+      - ./frontend:/app

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-name: sda-download-ui
-
 services:
 
   frontend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
         BUILD_GIT_COMMIT: "${BUILD_GIT_COMMIT:-}"
         BUILD_GIT_BRANCH: "${BUILD_GIT_BRANCH:-}"
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://frontend:3000"]
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3000').then(()=>process.exit(0)).catch(()=>process.exit(1))"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -46,7 +46,7 @@ services:
         BUILD_GIT_COMMIT: "${BUILD_GIT_COMMIT:-}"
         BUILD_GIT_BRANCH: "${BUILD_GIT_BRANCH:-}"
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://frontend:3000"]
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3000').then(()=>process.exit(0)).catch(()=>process.exit(1))"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,15 @@ services:
       start_period: 10s
     ports:
       - "3002:3000"
+    # approximate PSA restricted runtime constraints
+    user: "6001:6001"           # match your RUNTIME_ID (or whatever you use)
+    read_only: true             # similar to readOnlyRootFilesystem
+    security_opt:
+      - no-new-privileges:true  # like allowPrivilegeEscalation: false
+    cap_drop:
+      - ALL                     # like capabilities.drop: ["ALL"]
+    tmpfs:
+      - /tmp                    # provide a writable tmpfs for runtime needs
 
 
   frontend-dev:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+name: sda-download-ui
+
+services:
+
+  frontend:
+    profiles: ["prod"]
+    image: ghcr.io/nbisweden/sda-download-ui:${TAG:-latest}
+    build:
+      context: ./frontend
+      dockerfile: ../Dockerfile
+      target: prod
+      args:
+        BUILD_ID: "${BUILD_ID:-6000:6000}"
+        RUNTIME_ID: "${RUNTIME_ID:-6001:6001}"
+        BUILD_GIT_COMMIT: "${BUILD_GIT_COMMIT:-}"
+        BUILD_GIT_BRANCH: "${BUILD_GIT_BRANCH:-}"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://frontend:3000"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    ports:
+      - "3002:3000"
+
+
+  frontend-dev:
+    profiles: ["dev"]
+    image: ghcr.io/nbisweden/sda-download-ui:dev
+    build:
+      context: ./frontend
+      dockerfile: ../Dockerfile
+      target: dev
+      args:
+        BUILD_ID: "${BUILD_ID:-6000:6000}"
+        RUNTIME_ID: "${RUNTIME_ID:-6001:6001}"
+        BUILD_GIT_COMMIT: "${BUILD_GIT_COMMIT:-}"
+        BUILD_GIT_BRANCH: "${BUILD_GIT_BRANCH:-}"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://frontend:3000"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    ports:
+      - "3002:3000"
+    volumes:
+      - ./frontend:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,7 @@ name: sda-download-ui
 services:
 
   frontend:
-    profiles: ["prod"]
     image: ghcr.io/nbisweden/sda-download-ui:${TAG:-latest}
-    container_name: sda-download-UI
     build:
       context: ./frontend
       dockerfile: ../Dockerfile
@@ -22,11 +20,10 @@ services:
       retries: 5
       start_period: 10s
     ports:
-      - "3002:3000"
+      - 127.0.0.1:3002:3000
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    # approximate PSA restricted runtime constraints
-    user: "6001:6001"           # match your RUNTIME_ID (or whatever you use)
+
     read_only: true             # similar to readOnlyRootFilesystem
     security_opt:
       - no-new-privileges:true  # like allowPrivilegeEscalation: false
@@ -34,30 +31,3 @@ services:
       - ALL                     # like capabilities.drop: ["ALL"]
     tmpfs:
       - /tmp                    # provide a writable tmpfs for runtime needs
-
-
-  frontend-dev:
-    profiles: ["dev"]
-    image: ghcr.io/nbisweden/sda-download-ui:dev
-    container_name: sda-download-UI-dev
-    build:
-      context: ./frontend
-      dockerfile: ../Dockerfile
-      target: dev
-      args:
-        BUILD_ID: "${BUILD_ID:-6000:6000}"
-        RUNTIME_ID: "${RUNTIME_ID:-6001:6001}"
-        BUILD_GIT_COMMIT: "${BUILD_GIT_COMMIT:-}"
-        BUILD_GIT_BRANCH: "${BUILD_GIT_BRANCH:-}"
-    healthcheck:
-      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3000').then(()=>process.exit(0)).catch(()=>process.exit(1))"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
-    ports:
-      - "3002:3000"
-    extra_hosts:
-      - "host.docker.internal:host-gateway" # allow access to host services like mockauth and sda-auth
-    volumes:
-      - ./frontend:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
   frontend:
     profiles: ["prod"]
     image: ghcr.io/nbisweden/sda-download-ui:${TAG:-latest}
+    container_name: sda-download-UI
     build:
       context: ./frontend
       dockerfile: ../Dockerfile
@@ -22,6 +23,8 @@ services:
       start_period: 10s
     ports:
       - "3002:3000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     # approximate PSA restricted runtime constraints
     user: "6001:6001"           # match your RUNTIME_ID (or whatever you use)
     read_only: true             # similar to readOnlyRootFilesystem
@@ -36,6 +39,7 @@ services:
   frontend-dev:
     profiles: ["dev"]
     image: ghcr.io/nbisweden/sda-download-ui:dev
+    container_name: sda-download-UI-dev
     build:
       context: ./frontend
       dockerfile: ../Dockerfile
@@ -53,5 +57,7 @@ services:
       start_period: 10s
     ports:
       - "3002:3000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway" # allow access to host services like mockauth and sda-auth
     volumes:
       - ./frontend:/app

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -39,3 +39,8 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# build output
+.ash_history
+.cache
+node_modules.md5

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -19,7 +19,7 @@ if [ ! -d node_modules ] || [ ! -f node_modules.md5 ] ||
 then
 	echo 'Yes, running "npm ci"...' >&2
 	npm ci &&
-	run_md5sum >node_modules.md5
+	run_md5sum >node_modules.md5 || exit
 else
 	echo 'No, skipping "npm ci".' >&2
 fi

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh -
+
+set -u
+
+if [ "$SERVICE_MODE" = production ]; then
+	exec node server.js
+fi
+
+run_md5sum () {
+	find node_modules -type f -exec md5sum {} + | sort | md5sum
+}
+
+echo 'Do we need "npm ci"?' >&2
+
+if [ ! -d node_modules ] || [ ! -f node_modules.md5 ] ||
+   [ package-lock.json -nt node_modules ] ||
+   [ package-lock.json -nt node_modules.md5 ] ||
+   [ "$(cat node_modules.md5)" != "$(run_md5sum)" ]
+then
+	echo 'Yes, running "npm ci"...' >&2
+	npm ci &&
+	run_md5sum >node_modules.md5
+else
+	echo 'No, skipping "npm ci".' >&2
+fi
+
+exec npm run dev

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;


### PR DESCRIPTION
From my end this is complete, but I opened it as draft so that @andkaha has a look first.

## Related issue(s) and PR(s)

This PR closes #4.

It adds a Docker-based development and production workflow for sda-download-UI, including a multi-stage Dockerfile (similar to previous projects), compose profiles with helper scripts, and documentation updates. The production build runs the Next.js app as a standalone server (SSR-capable), and the Compose prod profile is hardened to better approximate Kubernetes “restricted” runtime constraints.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## List of changes made

- **Dockerfile + entrypoint**
  - Add a multi-stage `Dockerfile` with **dev** and **prod** targets.
  - Add a dev entrypoint script that automatically runs `npm ci` when needed and starts `next dev`.
  - Build the app in production using **Next.js standalone output** and run with `node server.js` (required for non-static/SSR behavior such as server-side JWT fetching).

- **Docker Compose + helper scripts**
  - Add a Compose file for `prod`-like and an override file for `dev` environments and respective helper scripts.
  - `compose-dev.sh` runs the dev environment and bind-mounts local frontend sources for development.
  - `compose-prod.sh` runs the prod environment for production-like builds and local testing.

- **Documentation**
  - Update the main README with instructions for building and running sdad in dev and prod modes.


## Testing

  ```sh
  ./compose-dev.sh up --build
  ```
Browse to http://localhost:3002.
  ```sh
  ./compose-dev.sh down
  ```

- **Prod-like**
  ```sh
  ./compose-prod.sh up --build
  ```
Browse to http://localhost:3002.
  ```sh
  ./compose-prod.sh down
  ```

## Further comments

I added a few runtime constraints to the prod profile of the compose so that we keep in mind a secure k8s cluster when testing locally the production image. This can be supplemented later with a named volume if the webapp needs any scratch storage.

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any
- [x] All Acceptance Criteria (AC) Fulfilled and checked in the Related issue

- [x] **Documentation Updated (if applicable):**
  - Relevant documentation is current.
  - Considerations: in-code comments, generated documentation, README files, Swagger docs, Postman collections, Confluence pages, etc.

## Folow-up issues

I opened #32 for collecting/documenting all necessary configuration to a file.