### PR TITLE
fix: silence Bootstrap Sass deprecation warnings

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,6 +2,14 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  sassOptions: {
+    silenceDeprecations: [
+      "import",
+      "global-builtin",
+      "color-functions",
+      "if-function",
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Related issue(s) and PR(s)

This PR closes #42 

<!-- Include below a description of the bug and the proposed fix -->

## Bug description

The frontend container logs were flooded with Sass deprecation warnings. They originate upstream in `node_modules/bootstrap` (Bootstrap 5.3.x still uses `@import`, global built-in functions, deprecated color functions, and the Sass `if()` function), so they can't be fixed in this repo.

## Fix implemented

Added `sassOptions.silenceDeprecations` to `frontend/next.config.ts` listing the four relevant categories: `import`, `global-builtin`, `color-functions`, `if-function`.

## Testing
- Verify that the deprecation warnings no longer appear in the container logs.

## Further comments
The silence list is scoped to known upstream issues in Bootstrap. When Bootstrap eventually migrates to modern Sass, we should revisit and remove entries that are no longer needed.

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
- [ ] Relevant tests have been added or updated
- [x] The fix has been verified manually, if applicable
