### PR TITLE
Extend sda dev test data

### DIFF
--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -164,10 +164,13 @@ curl -H "Authorization: Bearer $TOKEN" \
 
 The stack is pre-seeded with:
 
-- **Dataset**: `EGAD00000000001` (“Test Dataset”)
-- **File**: `EGAF00000000001` (`test-file.c4gh`, 1000 bytes archived,
-  500 bytes decrypted)
-- **User**: `integration_test@example.org` (file owner)
+- **Datasets**: `EGAD00000000001` through `EGAD00000000120`
+- **Files**:
+  - `EGAF00000000001` (`test-file.c4gh`, 1000 bytes archived, 500 bytes decrypted)
+  - Additional generated files distributed across the seeded datasets
+- **User**: `integration_test@example.org` (submission user / file owner)
+
+The mock OIDC token for `integration_test@example.org` includes visas for datasets `EGAD00000000001` through `EGAD00000000110`.
 
 ## Cleanup
 

--- a/dev-tools/mockoidc.py
+++ b/dev-tools/mockoidc.py
@@ -101,10 +101,10 @@ VISAS = {}
 
 
 def get_visas_for_user(sub: str) -> list:
-    """Get visas for a user, generating them if needed."""
     if sub not in VISAS:
         VISAS[sub] = [
-            generate_visa("EGAD00000000001", sub),
+            generate_visa(f"EGAD{i:011d}", sub)
+            for i in range(1, 111)
         ]
     return VISAS[sub]
 

--- a/dev-tools/seed.sh
+++ b/dev-tools/seed.sh
@@ -3,9 +3,25 @@
 # Creates a real Crypt4GH encrypted test file, uploads data segments to MinIO,
 # and inserts matching metadata (header, checksums, sizes) into the database.
 # Idempotent: safe to re-run against existing volumes.
+# Creates 120 datasets and reuses the base file for additional files.
+# It distributes files across the dataset  with a variable spread to support pagination testing.
+# Up to max 101 files per dataset.
 set -e
 
+SEED_MARKER="/shared/.download_v2_seeded"
+SEED_MARKER_TMP="/shared/.download_v2_seeded.tmp"
+
+if [ -f "$SEED_MARKER" ]; then
+  echo "Seed already completed, skipping."
+  exit 0
+fi
+
 echo "=== Seeding test data ==="
+
+SUBMISSION_USER="integration_test@example.org"
+BASE_FILE_UUID="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+BASE_FILE_STABLE_ID="EGAF00000000001"
+BASE_DATASET_STABLE_ID="EGAD00000000001"
 
 # Create deterministic plaintext test data (1 KB)
 python3 -c "import hashlib; open('/tmp/plaintext.bin','wb').write(hashlib.sha256(b'sda-download-v2-dev-test-data').digest() * 32)"
@@ -50,27 +66,68 @@ with open("/tmp/seed_metadata.env", "w") as f:
 print(f"Header: {len(header)} bytes, Body: {len(body)} bytes")
 PYEOF
 
-# Upload data segments to MinIO (overwrites if exists)
-mc alias set myminio http://s3:9000 access secretKey --quiet
-mc mb myminio/archive --ignore-existing --quiet
-mc pipe myminio/archive/test-file.c4gh < /tmp/body.bin
-echo "Uploaded to MinIO: archive/test-file.c4gh"
-
 # Load computed metadata
 . /tmp/seed_metadata.env
 
-# Seed database (upserts so reruns are safe with persistent volumes)
+# MinIO setup
+mc alias set myminio http://s3:9000 access secretKey --quiet
+mc mb myminio/archive --ignore-existing --quiet
+
+# Upload base archived object
+mc pipe myminio/archive/test-file.c4gh < /tmp/body.bin
+echo "Uploaded to MinIO: archive/test-file.c4gh"
+
+# Create all additional archived objects needed:
+# - files 2..101 for dataset 1
+# - a variable spread for datasets 2..120
+#
+# Global file sequence:
+#   1   = base file EGAF00000000001 => test-file.c4gh
+#   2+  = generated files => generated-file-XXXXXXXXXXX.c4gh
+#
+# Spread function for datasets 2..120:
+#   file_count = ((dataset_index - 2) % 10) + 1
+# This gives a repeating spread of 1..10 files across the remaining datasets.
+GLOBAL_FILE_SEQ=2
+
+# Additional archived objects for dataset 1 (100 more files)
+i=2
+while [ "$i" -le 101 ]; do
+  OBJ_NAME=$(printf "generated-file-%011d.c4gh" "$GLOBAL_FILE_SEQ")
+  mc cp "myminio/archive/test-file.c4gh" "myminio/archive/$OBJ_NAME" --quiet
+  GLOBAL_FILE_SEQ=$((GLOBAL_FILE_SEQ+1))
+  i=$((i+1))
+done
+
+# Archived objects for datasets 2..120 with spread 1..10
+dataset_idx=2
+while [ "$dataset_idx" -le 120 ]; do
+  file_count=$(( ((dataset_idx - 2) % 10) + 1 ))
+  j=1
+  while [ "$j" -le "$file_count" ]; do
+    OBJ_NAME=$(printf "generated-file-%011d.c4gh" "$GLOBAL_FILE_SEQ")
+    mc cp "myminio/archive/test-file.c4gh" "myminio/archive/$OBJ_NAME" --quiet
+    GLOBAL_FILE_SEQ=$((GLOBAL_FILE_SEQ+1))
+    j=$((j+1))
+  done
+  dataset_idx=$((dataset_idx+1))
+done
+
+echo "Uploaded/copied archived objects to MinIO"
+
+# Seed database
 pg_isready -h postgres -p 5432 -U postgres
 
 psql -h postgres -U postgres -d sda << EOSQL
+-- Base/original file
 INSERT INTO sda.files (
   id, stable_id, submission_user, submission_file_path,
   archive_file_path, archive_location, archive_file_size, decrypted_file_size,
   header, encryption_method
 ) VALUES (
-  'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
-  'EGAF00000000001',
-  'integration_test@example.org',
+  '$BASE_FILE_UUID',
+  '$BASE_FILE_STABLE_ID',
+  '$SUBMISSION_USER',
   'test-file.c4gh',
   'test-file.c4gh',
   'http://s3:9000/archive',
@@ -79,24 +136,147 @@ INSERT INTO sda.files (
   '$HEADER_HEX',
   'CRYPT4GH'
 ) ON CONFLICT (id) DO UPDATE SET
+  stable_id = EXCLUDED.stable_id,
   archive_file_size = EXCLUDED.archive_file_size,
   decrypted_file_size = EXCLUDED.decrypted_file_size,
-  header = EXCLUDED.header;
+  header = EXCLUDED.header,
+  archive_file_path = EXCLUDED.archive_file_path,
+  submission_file_path = EXCLUDED.submission_file_path;
 
+-- Base/original dataset
 INSERT INTO sda.datasets (stable_id, title)
-  VALUES ('EGAD00000000001', 'Test Dataset')
+  VALUES ('$BASE_DATASET_STABLE_ID', 'Test Dataset 001')
   ON CONFLICT (stable_id) DO NOTHING;
 
 INSERT INTO sda.file_dataset (file_id, dataset_id)
-  SELECT 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'::uuid, d.id
+  SELECT '$BASE_FILE_UUID'::uuid, d.id
   FROM sda.datasets d
-  WHERE d.stable_id = 'EGAD00000000001'
+  WHERE d.stable_id = '$BASE_DATASET_STABLE_ID'
   ON CONFLICT DO NOTHING;
 
-DELETE FROM sda.checksums WHERE file_id = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+DELETE FROM sda.checksums WHERE file_id = '$BASE_FILE_UUID';
 INSERT INTO sda.checksums (file_id, checksum, type, source) VALUES
-  ('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', '$ARCHIVE_CHECKSUM', 'SHA256', 'ARCHIVED'),
-  ('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', '$DECRYPTED_CHECKSUM', 'SHA256', 'UNENCRYPTED');
+  ('$BASE_FILE_UUID', '$ARCHIVE_CHECKSUM', 'SHA256', 'ARCHIVED'),
+  ('$BASE_FILE_UUID', '$DECRYPTED_CHECKSUM', 'SHA256', 'UNENCRYPTED');
 EOSQL
 
+# File sequence counter:
+# 1 is already used by the base file.
+NEXT_FILE_SEQ=2
+
+# Add 100 more files to the first dataset
+i=2
+while [ "$i" -le 101 ]; do
+  FILE_STABLE_ID=$(printf "EGAF%011d" "$NEXT_FILE_SEQ")
+  FILE_UUID=$(printf "aaaaaaaa-bbbb-cccc-dddd-%012d" "$NEXT_FILE_SEQ")
+  FILE_NAME=$(printf "generated-file-%011d.c4gh" "$NEXT_FILE_SEQ")
+
+  psql -h postgres -U postgres -d sda << EOSQL
+INSERT INTO sda.files (
+  id, stable_id, submission_user, submission_file_path,
+  archive_file_path, archive_location, archive_file_size, decrypted_file_size,
+  header, encryption_method
+) VALUES (
+  '$FILE_UUID',
+  '$FILE_STABLE_ID',
+  '$SUBMISSION_USER',
+  '$FILE_NAME',
+  '$FILE_NAME',
+  'http://s3:9000/archive',
+  $ARCHIVE_SIZE,
+  $DECRYPTED_SIZE,
+  '$HEADER_HEX',
+  'CRYPT4GH'
+) ON CONFLICT (id) DO UPDATE SET
+  stable_id = EXCLUDED.stable_id,
+  archive_file_size = EXCLUDED.archive_file_size,
+  decrypted_file_size = EXCLUDED.decrypted_file_size,
+  header = EXCLUDED.header,
+  archive_file_path = EXCLUDED.archive_file_path,
+  submission_file_path = EXCLUDED.submission_file_path;
+
+INSERT INTO sda.file_dataset (file_id, dataset_id)
+  SELECT '$FILE_UUID'::uuid, d.id
+  FROM sda.datasets d
+  WHERE d.stable_id = '$BASE_DATASET_STABLE_ID'
+  ON CONFLICT DO NOTHING;
+
+DELETE FROM sda.checksums WHERE file_id = '$FILE_UUID';
+INSERT INTO sda.checksums (file_id, checksum, type, source) VALUES
+  ('$FILE_UUID', '$ARCHIVE_CHECKSUM', 'SHA256', 'ARCHIVED'),
+  ('$FILE_UUID', '$DECRYPTED_CHECKSUM', 'SHA256', 'UNENCRYPTED');
+EOSQL
+
+  NEXT_FILE_SEQ=$((NEXT_FILE_SEQ+1))
+  i=$((i+1))
+done
+
+echo "Seeded 100 additional files into $BASE_DATASET_STABLE_ID"
+
+# Add datasets 2..120, each with a spread of files:
+#   file_count = ((dataset_index - 2) % 10) + 1
+dataset_idx=2
+while [ "$dataset_idx" -le 120 ]; do
+  DATASET_STABLE_ID=$(printf "EGAD%011d" "$dataset_idx")
+  DATASET_TITLE=$(printf "Test Dataset %03d" "$dataset_idx")
+  FILE_COUNT=$(( ((dataset_idx - 2) % 10) + 1 ))
+
+  psql -h postgres -U postgres -d sda << EOSQL
+INSERT INTO sda.datasets (stable_id, title)
+  VALUES ('$DATASET_STABLE_ID', '$DATASET_TITLE')
+  ON CONFLICT (stable_id) DO NOTHING;
+EOSQL
+
+  j=1
+  while [ "$j" -le "$FILE_COUNT" ]; do
+    FILE_STABLE_ID=$(printf "EGAF%011d" "$NEXT_FILE_SEQ")
+    FILE_UUID=$(printf "aaaaaaaa-bbbb-cccc-dddd-%012d" "$NEXT_FILE_SEQ")
+    FILE_NAME=$(printf "generated-file-%011d.c4gh" "$NEXT_FILE_SEQ")
+
+    psql -h postgres -U postgres -d sda << EOSQL
+INSERT INTO sda.files (
+  id, stable_id, submission_user, submission_file_path,
+  archive_file_path, archive_location, archive_file_size, decrypted_file_size,
+  header, encryption_method
+) VALUES (
+  '$FILE_UUID',
+  '$FILE_STABLE_ID',
+  '$SUBMISSION_USER',
+  '$FILE_NAME',
+  '$FILE_NAME',
+  'http://s3:9000/archive',
+  $ARCHIVE_SIZE,
+  $DECRYPTED_SIZE,
+  '$HEADER_HEX',
+  'CRYPT4GH'
+) ON CONFLICT (id) DO UPDATE SET
+  stable_id = EXCLUDED.stable_id,
+  archive_file_size = EXCLUDED.archive_file_size,
+  decrypted_file_size = EXCLUDED.decrypted_file_size,
+  header = EXCLUDED.header,
+  archive_file_path = EXCLUDED.archive_file_path,
+  submission_file_path = EXCLUDED.submission_file_path;
+
+INSERT INTO sda.file_dataset (file_id, dataset_id)
+  SELECT '$FILE_UUID'::uuid, d.id
+  FROM sda.datasets d
+  WHERE d.stable_id = '$DATASET_STABLE_ID'
+  ON CONFLICT DO NOTHING;
+
+DELETE FROM sda.checksums WHERE file_id = '$FILE_UUID';
+INSERT INTO sda.checksums (file_id, checksum, type, source) VALUES
+  ('$FILE_UUID', '$ARCHIVE_CHECKSUM', 'SHA256', 'ARCHIVED'),
+  ('$FILE_UUID', '$DECRYPTED_CHECKSUM', 'SHA256', 'UNENCRYPTED');
+EOSQL
+
+    NEXT_FILE_SEQ=$((NEXT_FILE_SEQ+1))
+    j=$((j+1))
+  done
+
+  dataset_idx=$((dataset_idx+1))
+done
+
+echo "Seeded 119 additional datasets with a spread of file counts for $SUBMISSION_USER"
+touch "$SEED_MARKER_TMP"
+mv "$SEED_MARKER_TMP" "$SEED_MARKER"
 echo "=== Seed complete ==="


### PR DESCRIPTION
## Description

This PR expands the test data that are loaded into the sda-dev stack environment.

## List of changes made

- Seed test environment with 120 datasets and expanded file coverage.
- First dataset has 101 files and the number of files in the others is randomly distriubuted
- update mock OIDC so user `integration_test@example.org` receives visas for the first 110 datasets.
- Make the seed script avoid executing if the data already exist in a created docker volume.

