### PR TITLE
fix: prevent nextjs from pre-building session dependent pages

### DIFF
--- a/frontend/src/app/lib/session.ts
+++ b/frontend/src/app/lib/session.ts
@@ -1,5 +1,5 @@
 import "server-only";
-
+import { connection } from "next/server";
 import * as jose from "jose";
 import { getSessionManager, SessionData } from "./SessionManager";
 
@@ -16,6 +16,7 @@ function _getOrDefault<T>(value: T | undefined, defaultValue: T): T {
 }
 
 export async function getSession(): Promise<SessionData | null> {
+  await connection();
   const sessionManager = await getSessionManager();
   return await sessionManager.getSession();
 }


### PR DESCRIPTION
## Related issue(s) and PR(s)

This PR closes #44

<!-- Include below a description of the bug and the proposed fix -->

## Bug description

Pages which used the session were pre-built in the nextjs build step which caused nextjs to use configuration variables that were not currently available. This prevented the system from building in production and from properly using the session information when the pages where accessed.

## Fix implemented

- Use nextjs functionality https://nextjs.org/docs/app/api-reference/functions/connection to prevent the page from rendering before a user request comes


## Testing

- Build for production `./compose-prod.sh build`
- Expect the system to build
- Run in production `./compose-prod.sh up`
- Go to the site
- Press the `Sign in` button
- Expect token information to be presented  

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
- [x] Relevant tests have been added or updated
- [x] The fix has been verified manually, if applicable
