### PR TITLE
53 create user info page

### DIFF
--- a/frontend/src/app/(pages)/userinfo/page.tsx
+++ b/frontend/src/app/(pages)/userinfo/page.tsx
@@ -1,0 +1,111 @@
+import { getSession } from "@/app/lib/session";
+import * as jose from "jose";
+import UserInfo from "@/app/components/UserInfo";
+
+export type TokenPayloadRow = {
+  label: string;
+  value: string;
+};
+
+export type TokenHeaderRow = {
+  label: string;
+  value: string;
+};
+
+function formatUnixTimestamp(value: unknown) {
+  if (typeof value !== "number") {
+    return "";
+  }
+
+  return new Date(value * 1000).toLocaleString("sv-SE", {
+    hour12: false,
+  });
+}
+
+function formatValue(value: unknown) {
+  if (value === undefined || value === null) {
+    return "";
+  }
+
+  if (Array.isArray(value)) {
+    return value.join(", ");
+  }
+
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+
+  return String(value);
+}
+
+function getPayloadRows(payload: jose.JWTPayload): TokenPayloadRow[] {
+  return [
+    { label: "Issuer", value: formatValue(payload.iss) },
+    { label: "Subject", value: formatValue(payload.sub) },
+    { label: "Audience", value: formatValue(payload.aud) },
+    { label: "Issued at", value: formatUnixTimestamp(payload.iat) },
+    { label: "Expires at", value: formatUnixTimestamp(payload.exp) },
+    { label: "Token ID", value: formatValue(payload.jti) },
+  ].filter((row) => row.value !== "");
+}
+
+function getHeaderRows(header: jose.ProtectedHeaderParameters): TokenHeaderRow[] {
+  return [
+    { label: "Algorithm", value: formatValue(header.alg) },
+    { label: "Type", value: formatValue(header.typ) },
+    { label: "Key ID", value: formatValue(header.kid) },
+  ].filter((row) => row.value !== "");
+}
+
+export default async function UserPage() {
+  const sessionData = await getSession();
+  const token = sessionData?.token;
+
+  let errorMessage: string | null = null;
+  let userName = "";
+  let payloadRows: TokenPayloadRow[] = [];
+  let headerRows: TokenHeaderRow[] = [];
+
+  if (!token) {
+    errorMessage = "No token found in session.";
+  } else {
+    try {
+      const payload = jose.decodeJwt(token);
+      const header = jose.decodeProtectedHeader(token);
+
+      userName = formatValue(
+        payload.sub ?? payload.email ?? payload["user"] ?? "Unknown user",
+      );
+      payloadRows = getPayloadRows(payload);
+      headerRows = getHeaderRows(header);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Unknown error occurred";
+      errorMessage = `Could not read token information: ${message}`;
+    }
+  }
+
+  return (
+    <main>
+      <div className="container">
+        <h2 className="my-3">User info</h2>
+        <div className="row">
+          {errorMessage ? (
+            <div className="col-12 col-lg-6">
+              <div className="alert alert-warning" role="alert">
+                <i className="bi bi-exclamation-triangle-fill fs-4 pe-1"></i>
+                {errorMessage}
+              </div>
+            </div>
+          ) : (
+            <UserInfo
+              userName={userName}
+              payloadRows={payloadRows}
+              headerRows={headerRows}
+            />
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/(pages)/userinfo/page.tsx
+++ b/frontend/src/app/(pages)/userinfo/page.tsx
@@ -2,12 +2,7 @@ import { getSession } from "@/app/lib/session";
 import * as jose from "jose";
 import UserInfo from "@/app/components/UserInfo";
 
-export type TokenPayloadRow = {
-  label: string;
-  value: string;
-};
-
-export type TokenHeaderRow = {
+export type TokenInfoRow = {
   label: string;
   value: string;
 };
@@ -38,22 +33,30 @@ function formatValue(value: unknown) {
   return String(value);
 }
 
-function getPayloadRows(payload: jose.JWTPayload): TokenPayloadRow[] {
+function getTokenInfoRows(payload: jose.JWTPayload): TokenInfoRow[] {
   return [
-    { label: "Issuer", value: formatValue(payload.iss) },
-    { label: "Subject", value: formatValue(payload.sub) },
-    { label: "Audience", value: formatValue(payload.aud) },
-    { label: "Issued at", value: formatUnixTimestamp(payload.iat) },
-    { label: "Expires at", value: formatUnixTimestamp(payload.exp) },
-    { label: "Token ID", value: formatValue(payload.jti) },
-  ].filter((row) => row.value !== "");
-}
-
-function getHeaderRows(header: jose.ProtectedHeaderParameters): TokenHeaderRow[] {
-  return [
-    { label: "Algorithm", value: formatValue(header.alg) },
-    { label: "Type", value: formatValue(header.typ) },
-    { label: "Key ID", value: formatValue(header.kid) },
+    {
+      label: "Signed in as",
+      value: formatValue(
+        payload.sub ?? payload.email ?? payload["user"] ?? "Unknown user",
+      ),
+    },
+    {
+      label: "Issued",
+      value: formatUnixTimestamp(payload.iat),
+    },
+    {
+      label: "Expires",
+      value: formatUnixTimestamp(payload.exp),
+    },
+    {
+      label: "Provided by",
+      value: formatValue(payload.iss),
+    },
+    {
+      label: "For application",
+      value: formatValue(payload.aud),
+    },
   ].filter((row) => row.value !== "");
 }
 
@@ -63,21 +66,18 @@ export default async function UserPage() {
 
   let errorMessage: string | null = null;
   let userName = "";
-  let payloadRows: TokenPayloadRow[] = [];
-  let headerRows: TokenHeaderRow[] = [];
+  let tokenInfoRows: TokenInfoRow[] = [];
 
   if (!token) {
     errorMessage = "No token found in session.";
   } else {
     try {
       const payload = jose.decodeJwt(token);
-      const header = jose.decodeProtectedHeader(token);
 
       userName = formatValue(
         payload.sub ?? payload.email ?? payload["user"] ?? "Unknown user",
       );
-      payloadRows = getPayloadRows(payload);
-      headerRows = getHeaderRows(header);
+      tokenInfoRows = getTokenInfoRows(payload);
     } catch (error) {
       const message =
         error instanceof Error ? error.message : "Unknown error occurred";
@@ -98,11 +98,7 @@ export default async function UserPage() {
               </div>
             </div>
           ) : (
-            <UserInfo
-              userName={userName}
-              payloadRows={payloadRows}
-              headerRows={headerRows}
-            />
+            <UserInfo userName={userName} tokenInfoRows={tokenInfoRows} />
           )}
         </div>
       </div>

--- a/frontend/src/app/components/UserInfo.tsx
+++ b/frontend/src/app/components/UserInfo.tsx
@@ -1,0 +1,84 @@
+import type {
+  TokenHeaderRow,
+  TokenPayloadRow,
+} from "@/app/(pages)/userinfo/page";
+
+type UserInfoProps = {
+  userName: string;
+  payloadRows: TokenPayloadRow[];
+  headerRows: TokenHeaderRow[];
+};
+
+export default function UserInfo({
+  userName,
+  payloadRows,
+  headerRows,
+}: UserInfoProps) {
+  return (
+    <div className="col-12 col-xl-8">
+      <div className="card shadow-sm">
+        <div className="card-body">
+          <h3 className="h4 mb-3">User {userName}</h3>
+          <h4 className="h5 mb-3">Token</h4>
+
+          <section className="mb-4">
+            <h5 className="h6">Payload</h5>
+            <div className="table-responsive">
+              <table className="table table-striped table-bordered align-middle">
+                <thead>
+                  <tr>
+                    <th scope="col">Param</th>
+                    <th scope="col">Value</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {payloadRows.map((row) => (
+                    <tr key={row.label}>
+                      <th scope="row">{row.label}</th>
+                      <td>{row.value}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section className="mb-4">
+            <h5 className="h6">Header</h5>
+            <div className="table-responsive">
+              <table className="table table-striped table-bordered align-middle">
+                <thead>
+                  <tr>
+                    <th scope="col">Param</th>
+                    <th scope="col">Value</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {headerRows.map((row) => (
+                    <tr key={row.label}>
+                      <th scope="row">{row.label}</th>
+                      <td>{row.value}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section>
+            <h5 className="h6">Set public encryption key</h5>
+            <label htmlFor="public-key-upload" className="form-label">
+              Select a public key to upload:
+            </label>
+            <input
+              id="public-key-upload"
+              type="file"
+              className="form-control"
+              disabled
+            />
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/components/UserInfo.tsx
+++ b/frontend/src/app/components/UserInfo.tsx
@@ -5,10 +5,7 @@ type UserInfoProps = {
   tokenInfoRows: TokenInfoRow[];
 };
 
-export default function UserInfo({
-  userName,
-  tokenInfoRows,
-}: UserInfoProps) {
+export default function UserInfo({ userName, tokenInfoRows }: UserInfoProps) {
   return (
     <div className="col-12 col-xl-8">
       <div className="card shadow-sm">

--- a/frontend/src/app/components/UserInfo.tsx
+++ b/frontend/src/app/components/UserInfo.tsx
@@ -1,74 +1,39 @@
-import type {
-  TokenHeaderRow,
-  TokenPayloadRow,
-} from "@/app/(pages)/userinfo/page";
+import type { TokenInfoRow } from "@/app/(pages)/userinfo/page";
 
 type UserInfoProps = {
   userName: string;
-  payloadRows: TokenPayloadRow[];
-  headerRows: TokenHeaderRow[];
+  tokenInfoRows: TokenInfoRow[];
 };
 
 export default function UserInfo({
   userName,
-  payloadRows,
-  headerRows,
+  tokenInfoRows,
 }: UserInfoProps) {
   return (
     <div className="col-12 col-xl-8">
       <div className="card shadow-sm">
         <div className="card-body">
-          <h3 className="h4 mb-3">User {userName}</h3>
           <h4 className="h5 mb-3">Token</h4>
 
-          <section className="mb-4">
-            <h5 className="h6">Payload</h5>
-            <div className="table-responsive">
-              <table className="table table-striped table-bordered align-middle">
-                <thead>
-                  <tr>
-                    <th scope="col">Param</th>
-                    <th scope="col">Value</th>
+          <div className="table-responsive mb-4">
+            <table className="table table-striped table-bordered align-middle">
+              <tbody>
+                {tokenInfoRows.map((row) => (
+                  <tr key={row.label}>
+                    <th scope="row" className="w-25">
+                      {row.label}
+                    </th>
+                    <td>{row.value}</td>
                   </tr>
-                </thead>
-                <tbody>
-                  {payloadRows.map((row) => (
-                    <tr key={row.label}>
-                      <th scope="row">{row.label}</th>
-                      <td>{row.value}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </section>
-
-          <section className="mb-4">
-            <h5 className="h6">Header</h5>
-            <div className="table-responsive">
-              <table className="table table-striped table-bordered align-middle">
-                <thead>
-                  <tr>
-                    <th scope="col">Param</th>
-                    <th scope="col">Value</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {headerRows.map((row) => (
-                    <tr key={row.label}>
-                      <th scope="row">{row.label}</th>
-                      <td>{row.value}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </section>
+                ))}
+              </tbody>
+            </table>
+          </div>
 
           <section>
-            <h5 className="h6">Set public encryption key</h5>
+            <h4 className="h5 mb-3">Crypt4gh public encryption key</h4>
             <label htmlFor="public-key-upload" className="form-label">
-              Select a public key to upload:
+              Select a crypt4gh public key to upload:
             </label>
             <input
               id="public-key-upload"

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -25,7 +25,7 @@ export default async function Home() {
             My Datasets
           </Link>
           <a className="btn btn-info m-1" href="/userinfo">
-              User info
+            User info
           </a>
 
           <form action={mockAuth}>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,12 +1,10 @@
 import mockAuth from "./actions/auth";
-import { getSession, getClaims } from "./lib/session";
+import { getSession } from "./lib/session";
 import Link from "next/link";
 
 export default async function Home() {
   const sessionData = await getSession();
-  const tokenInfo = sessionData?.token
-    ? await getClaims(sessionData.token)
-    : undefined;
+
   return (
     <div>
       <main>
@@ -26,6 +24,9 @@ export default async function Home() {
           <Link className="btn btn-success m-1" href="/datasets">
             My Datasets
           </Link>
+          <a className="btn btn-info m-1" href="/userinfo">
+              User info
+          </a>
 
           <form action={mockAuth}>
             <button className="btn btn-primary" type="submit">
@@ -33,17 +34,6 @@ export default async function Home() {
             </button>
           </form>
           <hr />
-          {tokenInfo ? (
-            <ul>
-              {Object.keys(tokenInfo).map((key) => (
-                <li key={key}>
-                  <em>{key}:</em> {String(tokenInfo[key])}
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <></>
-          )}
         </div>
         <div className="d-flex justify-content-between p-5">
           <button className="btn btn-primary">Primary</button>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -29,8 +29,12 @@ export default async function Home() {
           </a>
 
           <form action={mockAuth}>
-            <button className="btn btn-primary" type="submit">
-              Sign in
+            <button
+              className="btn btn-primary"
+              type="submit"
+              disabled={!!sessionData?.token}
+            >
+              {sessionData?.token ? "Signed in" : "Sign in"}
             </button>
           </form>
           <hr />


### PR DESCRIPTION
## Related issue(s) and PR(s)

This PR closes #53.

This adds a userinfo page that displays info from the token that is useful to the user and includes placeholder logic for uploading a c4gh public key

The `For application` is the `audience` field. I kept this for now but we can remove it later or make the value more human friendly.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Testing

Click on the userinfo button.
