### PR TITLE
62 avoid long pagination component

### DIFF
--- a/frontend/src/app/components/Pagination.tsx
+++ b/frontend/src/app/components/Pagination.tsx
@@ -22,7 +22,7 @@ export default function Pagination({
   const isFirstPage = currentPage === 1;
   const isLastPage = currentPage === totalPages;
 
-  const pageThreshold = 6;
+  const pageThreshold = 7;
 
   const getVisibleItems = () => {
     if (totalPages <= pageThreshold) {

--- a/frontend/src/app/components/Pagination.tsx
+++ b/frontend/src/app/components/Pagination.tsx
@@ -34,7 +34,14 @@ export default function Pagination({
     }
 
     if (currentPage >= totalPages - 2) {
-      return [1, "ellipsis-left", totalPages - 3, totalPages - 2, totalPages - 1, totalPages];
+      return [
+        1,
+        "ellipsis-left",
+        totalPages - 3,
+        totalPages - 2,
+        totalPages - 1,
+        totalPages,
+      ];
     }
 
     return [
@@ -85,26 +92,26 @@ export default function Pagination({
           </button>
         </li>
         {visibleItems.map((item) =>
-            typeof item === "number" ? (
-                <li
-                    key={item}
-                    className={`page-item ${item === currentPage ? "active" : ""}`}
-                    aria-current={item === currentPage ? "page" : undefined}
-                >
-                  <button
-                      type="button"
-                      className="page-link"
-                      onClick={() => onPageChange(item)}
-                      aria-label={`Go to page ${item}`}
-                  >
-                    {item}
-                  </button>
-                </li>
-            ) : (
-                <li key={item} className="page-item disabled" aria-hidden="true">
-                  <span className="page-link">…</span>
-                </li>
-            ),
+          typeof item === "number" ? (
+            <li
+              key={item}
+              className={`page-item ${item === currentPage ? "active" : ""}`}
+              aria-current={item === currentPage ? "page" : undefined}
+            >
+              <button
+                type="button"
+                className="page-link"
+                onClick={() => onPageChange(item)}
+                aria-label={`Go to page ${item}`}
+              >
+                {item}
+              </button>
+            </li>
+          ) : (
+            <li key={item} className="page-item disabled" aria-hidden="true">
+              <span className="page-link">…</span>
+            </li>
+          ),
         )}
 
         <li className={`page-item ${isLastPage ? "disabled" : ""}`}>

--- a/frontend/src/app/components/Pagination.tsx
+++ b/frontend/src/app/components/Pagination.tsx
@@ -5,7 +5,7 @@ type PaginationProps = {
   totalItems?: number;
   currentPage: number;
   totalPages: number;
-  onPageChange: (page: number) => void;
+  onPageChange: (page: number | string) => void;
 };
 
 export default function Pagination({
@@ -19,13 +19,36 @@ export default function Pagination({
     return null;
   }
 
-  const pageNumbers = Array.from(
-    { length: totalPages },
-    (_, index) => index + 1,
-  );
-
   const isFirstPage = currentPage === 1;
   const isLastPage = currentPage === totalPages;
+
+  const pageThreshold = 6;
+
+  const getVisibleItems = () => {
+    if (totalPages <= pageThreshold) {
+      return Array.from({ length: totalPages }, (_, index) => index + 1);
+    }
+
+    if (currentPage <= 3) {
+      return [1, 2, 3, 4, "ellipsis-right", totalPages];
+    }
+
+    if (currentPage >= totalPages - 2) {
+      return [1, "ellipsis-left", totalPages - 3, totalPages - 2, totalPages - 1, totalPages];
+    }
+
+    return [
+      1,
+      "ellipsis-left",
+      currentPage - 1,
+      currentPage,
+      currentPage + 1,
+      "ellipsis-right",
+      totalPages,
+    ];
+  };
+
+  const visibleItems = getVisibleItems();
 
   let startItem;
   let endItem;
@@ -45,7 +68,8 @@ export default function Pagination({
             onClick={() => onPageChange(1)}
             disabled={isFirstPage}
           >
-            First
+            <span className="d-inline d-sm-none">&lt;&lt;</span>
+            <span className="d-none d-sm-inline">First</span>
           </button>
         </li>
 
@@ -56,26 +80,32 @@ export default function Pagination({
             onClick={() => onPageChange(currentPage - 1)}
             disabled={isFirstPage}
           >
-            <span className="d-inline d-sm-none">&lt;&lt;</span>
+            <span className="d-inline d-sm-none">&lt;</span>
             <span className="d-none d-sm-inline">Previous</span>
           </button>
         </li>
-
-        {pageNumbers.map((pageNumber) => (
-          <li
-            key={pageNumber}
-            className={`page-item ${pageNumber === currentPage ? "active" : ""}`}
-            aria-current={pageNumber === currentPage ? "page" : undefined}
-          >
-            <button
-              type="button"
-              className="page-link"
-              onClick={() => onPageChange(pageNumber)}
-            >
-              {pageNumber}
-            </button>
-          </li>
-        ))}
+        {visibleItems.map((item) =>
+            typeof item === "number" ? (
+                <li
+                    key={item}
+                    className={`page-item ${item === currentPage ? "active" : ""}`}
+                    aria-current={item === currentPage ? "page" : undefined}
+                >
+                  <button
+                      type="button"
+                      className="page-link"
+                      onClick={() => onPageChange(item)}
+                      aria-label={`Go to page ${item}`}
+                  >
+                    {item}
+                  </button>
+                </li>
+            ) : (
+                <li key={item} className="page-item disabled" aria-hidden="true">
+                  <span className="page-link">…</span>
+                </li>
+            ),
+        )}
 
         <li className={`page-item ${isLastPage ? "disabled" : ""}`}>
           <button
@@ -84,7 +114,7 @@ export default function Pagination({
             onClick={() => onPageChange(currentPage + 1)}
             disabled={isLastPage}
           >
-            <span className="d-inline d-sm-none">&gt;&gt;</span>
+            <span className="d-inline d-sm-none">&gt;</span>
             <span className="d-none d-sm-inline">Next</span>
           </button>
         </li>
@@ -96,17 +126,18 @@ export default function Pagination({
             onClick={() => onPageChange(totalPages)}
             disabled={isLastPage}
           >
-            Last
+            <span className="d-inline d-sm-none">&gt;&gt;</span>
+            <span className="d-none d-sm-inline">Last</span>
           </button>
         </li>
         {itemsPerPage && totalItems && (
-          <p className="ms-3 ms-lg-4 my-3 my-lg-0 align-self-center">
+          <li className="ms-3 ms-lg-4 my-3 my-lg-0 align-self-center">
             Viewing{" "}
             <strong>
               {startItem}-{endItem}
             </strong>{" "}
             of <strong>{totalItems}</strong>
-          </p>
+          </li>
         )}
       </ul>
     </nav>


### PR DESCRIPTION
<!-- Remove sections from this template that are not used -->

## Related issue(s) and PR(s)

This PR closes #62 

Make pagination component less long if there are many pages to show and more responsive

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## List of changes made

- Made the pagination show less pages 
- The first and last page are always shown
- The ellipsis (...) is added where needed when the numbers are not sequential (see screenshots)
- Changed to arrows in mobile view for First/Last as well

## Screenshot of the fix
Depending on which page is shown:
Only one ellipsis (...)
<img width="638" height="283" alt="Screenshot from 2026-05-06 16-20-51" src="https://github.com/user-attachments/assets/87c576be-c552-46ef-9e02-df89a24da073" />

<img width="638" height="283" alt="Screenshot from 2026-05-06 16-20-58" src="https://github.com/user-attachments/assets/21531e1c-6851-490b-af37-da5a74ba23dd" />
The page is in the middle so there are ellipsis between the first page and the pages in the middle and the last page
<img width="697" height="255" alt="image" src="https://github.com/user-attachments/assets/2094cebb-d381-43e2-a65f-b856bc9c878c" />

Small screens:

<img width="300" height="649" alt="Screenshot from 2026-05-06 16-21-36" src="https://github.com/user-attachments/assets/4fe30b05-38d5-4ef0-ada1-deea6b480fad" />
In some cases it will intentionally break to the next line: 
<img width="300" height="649" alt="Screenshot from 2026-05-06 16-21-46" src="https://github.com/user-attachments/assets/649d10a0-28e2-45d9-af6e-7686121fada5" />

## Further comments

I looked at a [Medium article ](https://coyleandrew.medium.com/design-better-pagination-a022a3b161e1)on pagination on how to improve it in the best way.
For very small screens as mobile the pagination will go onto next row intentionally. It would be possible to make a different amount of shown pages for mobile view but since the application is not a mobile first and it works fine even for smaller I went for this general solution. 

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any
- [x] All Acceptance Criteria (AC) Fulfilled and checked in the Related issue
