### PR TITLE
docs: add document on dataset downloading options

### DIFF
--- a/docs/dataset_download.md
+++ b/docs/dataset_download.md
@@ -1,0 +1,283 @@
+# Bulk Dataset Download — Decision Meeting Document
+
+**Purpose:** Decide which solution to implement for the "Download dataset" feature.
+**Outcome required:** Pick (a) the short-term implementation and (b) the long-term direction.
+
+---
+
+## 1. Context
+
+### User story
+> As a user, I want to click on a "Download dataset" button so that I can download a whole dataset with minimal intervention.
+
+### Key facts
+- A dataset may contain **tens of thousands of files**.
+- Each file may be **several GB** in size.
+- Users may also want to download **a subset** of a dataset (e.g. 30–50 selected files).
+- Expected UX: **click once, leave it running unattended for hours/days, come back later**.
+- The download API supports **file-by-file download only** — no dataset archive endpoint.
+- The download API authenticates with the **same session JWT** the web app already uses.
+- Users are primarily on **Windows machines, often restricted, without WSL**.
+- Some Ubuntu support is also required.
+- The current web app is a Next.js application running in a standard browser.
+- A native CLI tool, **`sda-cli`**, already exists for Windows and Ubuntu and supports dataset download:
+
+```bash
+./sda-cli --config <config_file> download \
+  --pubkey <public-key-file> \
+  --dataset-id <datasetID> \
+  --url <download-service-URL> <filepath>
+```
+
+- `sda-cli` requires an `s3cmd`-style config file. All required values are available from the user's session JWT and app configuration.
+
+### Why the browser is generally not ideal for full-dataset workloads
+For very large transfers, the browser is best used as a **control plane**:
+- authenticate
+- browse/select datasets
+- initiate transfers
+
+A **native process** is best for the **data plane**:
+- run for hours/days
+- retry/resume
+- survive browser closure
+- handle thousands of large files reliably
+
+A browser-only solution is nonetheless feasible within known limits and is the right answer for **small-batch** downloads of selected files (see §4).
+
+---
+
+## 2. Problem statement
+
+We need a "Download dataset" solution that:
+- handles **full datasets** (tens of thousands of files, multi-GB each) robustly
+- handles **small batches** (30–50 selected files) with a native per-file UX
+- is usable on restricted Windows machines (and Ubuntu)
+- aligns with existing `sda-cli` tooling where applicable
+- is implementable in the current Next.js architecture
+
+---
+
+## 3. Options considered
+
+The discussion narrows to three concrete approaches that, together, cover the full range of use cases:
+
+### Option A — Full dataset via `sda-cli` handoff
+**Description:** UI generates everything `sda-cli` needs and instructs the user to run it locally:
+- generated `s3cmd`-style config (from session JWT + app config)
+- copyable Windows command
+- optional `.cmd` and PowerShell helpers
+- optional Ubuntu shell script
+- public-key file selection in the UI
+- clear OS-specific instructions
+
+**Pros:** robust at scale; reuses existing native tool; works on Windows + Ubuntu; implementable now; survives browser closure; supports multi-day unattended transfers.
+**Cons:** not truly one-click; user must have `sda-cli` installed; some manual action remains; care needed around the session JWT in the generated config.
+
+### Option B — Full dataset in Chromium via File System Access API + ZIP streaming fallback
+**Description:** A purely in-browser implementation for full-dataset downloads, with the technique chosen automatically based on the user's browser.
+
+- **On Chromium (Chrome / Edge):** use the File System Access API to write directly into a user-chosen folder, file by file, with a Web Worker pool, streaming `fetch`, IndexedDB manifest, and per-file `Range` resume.
+- **On Firefox / Safari 14.1+:** use a Service Worker to intercept a virtual URL (e.g. `/__archive/dataset-123.zip`) and stream a ZIP64 archive built on the fly with `client-zip`, fed by sequential authenticated `fetch` streams. The browser saves one big `.zip` that the user unzips at the end.
+
+**Pros:** zero install; no CLI, no helper, no extension; works on locked-down machines that forbid local tooling; single Next.js codebase; covers all major desktop browsers.
+**Cons:** tab must stay open for the entire transfer; ~6 connections-per-origin cap; Firefox/Safari archive mode has no resume and is single-connection bandwidth bound; no mobile Safari support; throughput sensitive to corporate AV/proxy; truly unattended multi-day transfers are not realistic.
+
+### Option C — Small batches (30–50 files) via simulated per-file clicks
+**Description:** A purely in-browser implementation for **small subsets** of a dataset — typically 30–50 selected files — where the user expectation is "a few normal downloads", not "a bulk transfer".
+
+- Loop sequentially over the selected files.
+- For each file, trigger a save by clicking a hidden `<a download="...">`.
+- Authentication: a Service Worker intercepts a virtual URL (e.g. `/__sw-download/<fileId>`) and proxies an authenticated `fetch`, streaming the response back to the browser's download manager.
+- Wait for each file's stream to close before triggering the next, to avoid throttling.
+- Show a per-file progress list: queued / downloading / done / failed.
+
+**Pros:** native per-file UX — files land individually in the user's Downloads folder; no archive to unzip; zero install; multi-GB safe through streaming; works in all major desktop browsers within the size limit.
+**Cons:** folder structure flattened; no per-file resume on connection drop; "Save As" dialogs cannot be silenced by the page; reliable only up to ~50 files (Safari deduplicates above that, Firefox throttles, Chromium prompts once for "multiple downloads").
+
+---
+
+## 4. Detailed design
+
+### 4.1 Working assumptions
+- Users may keep the tab open for hours or days when needed.
+- The session JWT TTL is long enough for the entire transfer.
+- The download API is per-file, authenticated with the session JWT.
+- Selections range from a handful of files to the full dataset.
+
+### 4.2 The three flows in one architecture
+
+```
+                ┌─────────────────────────────────────────┐
+                │       User clicks "Download"            │
+                └───────────────────┬─────────────────────┘
+                                    │
+              ┌─────────────────────┴────────────────────┐
+              │ Selection size?                          │
+              └─┬──────────────────────────────────────┬─┘
+                │                                      │
+       ≤ ~30–50 files                       large selection / full dataset
+                │                                      │
+                ▼                                      ▼
+   ┌───────────────────────┐            ┌──────────────────────────┐
+   │ Option C              │            │ Browser only?            │
+   │ Per-file simulated    │            └─────────┬────────────────┘
+   │ clicks via SW proxy   │                      │
+   └───────────────────────┘             ┌────────┴────────┐
+                                      yes                  no
+                                         │                  │
+                                         ▼                  ▼
+                              ┌────────────────────┐  ┌──────────────────┐
+                              │ Option B           │  │ Option A         │
+                              │ Chromium: folder   │  │ sda-cli handoff  │
+                              │ Other: ZIP stream  │  │ (Windows/Ubuntu) │
+                              └────────────────────┘  └──────────────────┘
+```
+
+### 4.3 Option A — `sda-cli` for full datasets
+
+**When:** large selections / full datasets, when local tooling is acceptable.
+
+**Flow:**
+1. User clicks **Download dataset**.
+2. UI gathers public key and (optionally) destination path guidance.
+3. Backend assembles, just-in-time:
+   - `config.ini` (s3cmd-style, with the session JWT)
+   - `run.cmd` (Windows, double-clickable, avoids PowerShell ExecutionPolicy issues)
+   - optional `run.ps1` (PowerShell)
+   - optional `run.sh` (Ubuntu)
+   - `README.txt` with prerequisites and security warning
+   - optionally bundled `sda-cli.exe` / `sda-cli` binaries
+4. Bundle is streamed back as a ZIP and saved by the browser.
+5. User unzips and double-clicks `run.cmd`.
+
+**Why this is the right answer for full datasets:**
+- Multi-day, resumable, parallel transfer that survives browser closure.
+- Reuses an existing native tool built for this exact workload.
+- No browser concurrency cap, no tab-lifecycle constraint.
+
+**Care points:**
+- `config.ini` carries the session JWT — bundle is sensitive.
+- Generate just-in-time, never persist server-side, never log contents.
+- Include a security warning in `README.txt`.
+- (Optional) offer a passphrase to encrypt `config.ini` at rest.
+
+### 4.4 Option B — Browser-only full-dataset download
+
+**When:** browser-only is required (locked-down machines, no install allowed).
+
+#### Chromium path — folder mode
+- `showDirectoryPicker()` once at the start; handle persisted in IndexedDB.
+- Coordinator Web Worker drives a pool of 4 download workers.
+- Each worker streams one file with `fetch().body.pipeTo(writableStream)` — bytes never sit in JS memory.
+- Per-file state in IndexedDB (URL, path, size, bytesWritten, status, retries).
+- HTTP `Range` requests resume any individual file from `bytesWritten` after a network drop.
+- Resume across accidental tab close on next visit.
+
+**Delivers:** native folder tree, parallel transfers, per-file resume, multi-GB safe via streaming.
+
+#### Firefox / Safari 14.1+ path — ZIP streaming
+- Service Worker scoped to the app intercepts a virtual URL (e.g. `/__archive/dataset-123.zip`).
+- Returns a streamed `Response` whose body is a ZIP64 archive built on the fly with [`client-zip`](https://github.com/Touffy/client-zip) (STORE-only, no compression — files are already large/incompressible).
+- The encoder pulls each file via authenticated `fetch` and emits archive bytes incrementally.
+- Browser writes one big `.zip` file via its normal download manager.
+
+**Delivers:** one save prompt, one resulting `.zip`, true streaming, multi-GB safe, no backend change.
+
+**Limits:** no resume (connection drop = whole archive restarts); effectively single-connection throughput; user must unzip at the end (recommend 7-Zip on Windows over Explorer's built-in unzip); SW crash truncates the archive; mobile Safari unsupported.
+
+#### Runtime selection within Option B
+
+```js
+const caps = await detectCapabilities();
+
+if (caps.fileSystemAccess) {
+  return runFolderMode();          // Chromium
+} else if (caps.serviceWorkerStreaming) {
+  return runArchiveMode();         // Firefox / Safari 14.1+
+} else {
+  return showUnsupportedMessage();
+}
+```
+
+### 4.5 Option C — Simulated per-file clicks for small batches
+
+**When:** the user has selected a small subset of a dataset (≤ ~30–50 files).
+
+**Flow:**
+1. UI shows a per-file progress list.
+2. For each file, sequentially:
+   - Create a hidden `<a>` pointing to a Service Worker virtual URL: `/__sw-download/<fileId>`.
+   - Click it. The SW intercepts, issues an authenticated `fetch`, and streams the response back to the browser's download manager.
+   - Wait for the SW stream to close before moving to the next file (best available signal for "this file is done").
+3. On completion, show the user a summary with any failures.
+
+**Browser behavior at 30–50 files:**
+
+| Browser | Behavior |
+|---|---|
+| Chrome / Edge | One "Allow multiple downloads" prompt on the second file, then OK. Reliable. |
+| Firefox | Throttles rapid programmatic downloads. Sequential pacing avoids most drops. |
+| Safari desktop | Aggressive deduplication; works for small counts when paced sequentially. **Above ~50 it becomes unreliable.** |
+| Safari iOS | Not supported. |
+
+**Why a separate mode and not a fallback of Option B:**
+- For small selections, users expect files in their Downloads folder, not a ZIP to unzip.
+- An archive UX is heavy-handed for 30–50 files.
+- Per-file mode preserves the "normal download" mental model.
+
+**Limits:**
+- Folder structure is flattened (workaround: encode paths into filenames).
+- No per-file resume on connection drop.
+- "Save As" dialogs cannot be silenced by the page; if the user has *"always ask where to save"* enabled they get one prompt per file. Acceptable at 30–50, painful beyond.
+- Hard ceiling near 50 files; above that, switch to Option B's archive mode (or to Option A if installed).
+
+### 4.6 Common foundations across browser-based modes (B and C)
+- Authenticated `fetch` with the session JWT (via Service Worker for `<a download>` paths).
+- Streaming everywhere; no `await response.blob()`.
+- Bounded retries with exponential backoff and jitter per file.
+- Pre-flight storage estimate via `navigator.storage.estimate()`.
+- Wake Lock where available.
+- `beforeunload` warning and "Do not close this tab" banner.
+- Cancel button that cleanly aborts in-flight `fetch` and SW streams.
+- Verification step at the end: expected vs delivered files, with a clear failure list.
+
+### 4.7 Backend prerequisites
+
+| Requirement | Option A | Option B | Option C |
+|---|---|---|---|
+| Per-file endpoints with JWT in `Authorization` | ✅ | ✅ | ✅ |
+| CORS allowing the web origin, `Content-Length` exposed | — | ✅ | ✅ |
+| `Range` request support | nice-to-have | required (Chromium) | nice-to-have |
+| Bundle-generation endpoint (`config.ini` + scripts + binaries) | ✅ | — | — |
+| Service Worker scope on the app origin | — | ✅ | ✅ |
+
+### 4.8 What each option delivers to the user
+
+| Aspect | Option A (sda-cli) | Option B Chromium | Option B Firefox/Safari | Option C |
+|---|---|---|---|---|
+| Best for | Full dataset | Full dataset | Full dataset | 30–50 files |
+| Install required | `sda-cli` | None | None | None |
+| Prompts | Unzip + double-click | One folder pick | One save dialog | One per file (or "allow multiple") |
+| Output | Native folder tree | Native folder tree | One `.zip` to unzip | Files in Downloads |
+| Concurrency | Parallel, native | 4 parallel | Effectively 1 | Sequential (paced) |
+| Per-file resume | Yes | Yes | No | No |
+| Tab lifecycle | Browser can be closed | Tab must stay open | Tab must stay open | Tab must stay open |
+| Multi-GB files | Yes | Yes | Yes | Yes |
+| Multi-day unattended | Yes | No | No | No |
+
+---
+
+## 5. Recommendation
+
+### Short term
+
+- **Full datasets → Option A: `sda-cli` handoff.** This is the only realistic answer for tens of thousands of files at multi-GB each. The browser is the control plane; `sda-cli` is the data plane.
+- **Small batches (≤ ~30–50 files) → Option C: simulated per-file clicks.** Native per-file UX, zero install, ships from the same Next.js codebase.
+- **Browser-only full-dataset path (Option B) optional from day one.** Implement it if zero-install full-dataset downloads are a hard requirement for some users; otherwise treat as a future extension.
+
+### Long term
+
+- Reduce handoff friction on Option A by moving toward a **thin native launcher** and eventually a **custom protocol handler** (`sda-download://`).
+- Keep Option C as the small-batch path indefinitely — it is the right tool for that job.
+- Reconsider Option B as browser capabilities evolve (broader File System Access support, better Service Worker reliability).

--- a/docs/tar-download.md
+++ b/docs/tar-download.md
@@ -1,0 +1,336 @@
+# SDA Download UI — Bulk Download Architecture
+
+**Status:** Proposed implementation.
+**Companion to:** *Bulk Dataset Download — Decision Meeting Document*.
+
+---
+
+## 1. Context
+
+### 1.1 What we have today
+
+A Next.js proxy in front of the SDA Data Out API that handles session-cookie auth, attaches the Crypt4GH public key to upstream calls, stitches header + content, and supports `Range`/`If-Range` on a stable per-file ETag.
+
+```mermaid
+flowchart LR
+    B[Browser] -- cookie --> P[Next.js proxy<br/>/api/files/&#123;id&#125;]
+    P -- bearer + public key --> S[SDA Data Out API]
+    S -- header + content --> P
+    P -- bytes --> B
+```
+
+### 1.2 What we are adding
+
+A **bulk download** path: one click delivers a whole dataset (or a selected subset) as a single resumable file, with folder structure preserved, no new install, reusing the existing session and key model.
+
+### 1.3 Where this sits
+
+This is a **server-side variant of Option B** in the decision document — zero-install, one-click, no Service Worker. Not a replacement for Option A (`sda-cli`) for multi-day unattended transfers.
+
+---
+
+## 2. Goals and non-goals
+
+**Goals:** one-click bulk download, folder structure preserved, resumable, no new install, reuses existing auth + key, no new persistent server state.
+
+**Non-goals:** unattended multi-day transfers, compression, plaintext re-encryption, intra-stream parallelism.
+
+---
+
+## 3. Working assumptions
+
+1. **Header length stability.** `Content-Length` of `GET /files/{id}/header` is constant per `(fileId, key)`. Header *bytes* may vary.
+2. **Header reuse within an emit.** Once a header is fetched in a request, we splice content onto those bytes; we never resume mid-header.
+3. **Content stability.** `/content` is byte-stable with `Range` + stable ETag (spec).
+4. **Session lifetime** covers the whole transfer.
+5. **One concurrent bulk download per user.**
+6. **Dataset immutability** for a given `datasetId` (spec).
+
+---
+
+## 4. The proposed architecture
+
+New route:
+
+```
+GET  /api/datasets/{datasetId}/download.tar[?fileIds=<csv>]
+HEAD /api/datasets/{datasetId}/download.tar[?fileIds=<csv>]
+```
+
+Streams a **deterministic, store-only POSIX TAR (PAX/USTAR)** containing the dataset's `.c4gh` files at their original `filePath`s.
+
+### 4.1 Component view
+
+```mermaid
+flowchart TB
+    subgraph Browser
+        DD["DatasetDetails: Download dataset"]
+        DF["DatasetFiles: Download selected as TAR"]
+        DM[Browser download manager<br/>pause / resume / save]
+        DD --> DM
+        DF --> DM
+    end
+
+    subgraph "Next.js (Node runtime)"
+        R["/api/datasets/&#123;id&#125;/download.tar"]
+        MB["Manifest builder (HEAD only)"]
+        RP[Region planner]
+        TS[TAR streamer<br/>Node Readable]
+        R --> MB --> RP --> TS
+    end
+
+    subgraph "SDA Data Out API"
+        HH["HEAD /files/&#123;id&#125;/header"]
+        HC["HEAD /files/&#123;id&#125;/content"]
+        GH["GET /files/&#123;id&#125;/header"]
+        GC["GET /files/&#123;id&#125;/content"]
+    end
+
+    DM -- cookie + Range/If-Range --> R
+    TS -- bytes --> DM
+    MB -- bearer + key --> HH
+    MB -- bearer --> HC
+    TS -- bearer + key, lazy --> GH
+    TS -- bearer + Range --> GC
+```
+
+### 4.2 Why TAR
+
+Store-only TAR has no trailing index, so byte offsets are a pure function of the manifest — making `Range` resume safe and deterministic. ZIP's central directory at the end makes mid-stream resume effectively impossible.
+
+### 4.3 The resume invariant
+
+For any byte offset `N`:
+
+- **Static regions** (PAX/USTAR blocks, padding, trailer): deterministic from the manifest.
+- **Content bytes**: upstream-stable per Assumption 3.
+- **Header bytes**: length-stable per Assumption 1; pinned within a request per Assumption 2.
+
+The ETag (§5.4) binds the inputs; any change flips it and forces a clean 200.
+
+### 4.4 Archive layout
+
+```mermaid
+flowchart LR
+    PAX["paxBlock?<br/>(optional, k*512)"] --> UB["ustarBlock<br/>(512)"]
+    UB --> CH["c4ghHeader<br/>(headerLen)"]
+    CH --> CC["c4ghContent<br/>(contentLen)"]
+    CC --> P["padding<br/>(to 512)"]
+```
+
+```
+archive := entry[0] | entry[1] | … | entry[N-1] | TRAILER(1024 zero bytes)
+```
+
+Entries sorted by `filePath` (byte-lexicographic). No directory entries. Fixed `mode=0644`, `uid=gid=0`, `mtime=dataset.date`.
+
+### 4.5 Response headers
+
+| Header                | Value                                       |
+| --------------------- | ------------------------------------------- |
+| `Content-Type`        | `application/x-tar`                         |
+| `Content-Disposition` | `attachment; filename="<datasetId>.tar"…`   |
+| `Content-Length`      | precomputed total                           |
+| `Accept-Ranges`       | `bytes`                                     |
+| `ETag`                | sha256 over manifest + key + layout version |
+| `Cache-Control`       | `no-store`                                  |
+
+### 4.6 Resume protocol
+
+Standard HTTP — browser download managers and `curl -C -` already speak it. Ranges that land mid-header are refused and we fall through to a full 200.
+
+---
+
+## 5. Data flow
+
+### 5.1 Happy path
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant B as Browser
+    participant N as Next.js route
+    participant M as Manifest builder
+    participant S as SDA API
+
+    B->>N: GET .../download.tar
+    N->>M: build manifest
+    par 32 workers
+        M->>S: HEAD /header (per file)
+        M->>S: HEAD /content (per file)
+    end
+    S-->>M: lengths + content ETags
+    M-->>N: plan, ETag, totalLen
+    N-->>B: 200 + ETag + Content-Length
+
+    loop per entry
+        N-->>B: paxBlock? + ustarBlock
+        N->>S: GET /header (lazy)
+        S-->>N: header bytes (cache + emit)
+        N->>S: GET /content (stream)
+        S-->>N: content stream
+        N-->>B: content bytes
+        N-->>B: padding zeros
+    end
+    N-->>B: TRAILER + EOF
+```
+
+### 5.2 Resume path
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant B as Browser
+    participant N as Next.js route
+    participant M as Manifest builder
+    participant S as SDA API
+
+    B->>N: GET Range: bytes=N-<br/>If-Range: <etag>
+    N->>M: rebuild manifest
+    M->>S: HEAD /header + /content
+    S-->>M: same lengths + ETags
+    M-->>N: same ETag
+
+    alt ETag matches and N is in a content region
+        N-->>B: 206 + Content-Range
+        N->>S: GET /content with Range: bytes=within-…
+        S-->>N: partial content stream
+        N-->>B: bytes
+    else N falls inside a header region
+        N-->>B: 200 full body (refuse range)
+    else ETag mismatch
+        N-->>B: 200 full body
+    end
+```
+
+### 5.3 Manifest build
+
+Concurrent (default 32) `HEAD /header` + `HEAD /content` per file. From the results we precompute `plan[i]`, prefix sums `entryStart[i]`, `totalLen`, and the ETag.
+
+### 5.4 ETag
+
+```
+sha256(
+  "sda-tar-v1\n" + pemChecksum + "\n" +
+  for each entry: fileId \t contentEtag \t filePath \n
+)
+```
+
+Header *bytes* are deliberately excluded — only their length matters (Assumption 1). The ETag is stable across process restarts.
+
+### 5.5 Streamer state
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> DrainContent: active reader & bytes left
+    Idle --> CheckEnd: no reader
+    CheckEnd --> EOF: pos >= end
+    CheckEnd --> EmitStatic: region is static
+    CheckEnd --> OpenContent: region is content
+    EmitStatic --> Idle: push chunk, advance
+    OpenContent --> DrainContent: reader opened
+    DrainContent --> Idle: push chunk; if region drained, advance
+    EOF --> [*]
+```
+
+### 5.6 Lazy header fetching
+
+Headers fetched on first emit, verified against the `HEAD` length, cached per entry for the lifetime of the request.
+
+### 5.7 Memory and concurrency
+
+- ~2 KB per file for tar planning; ~124 B per touched header; ~1.2 MB total for a 10k-file pass.
+- Pre-stream: 32 concurrent HEADs.
+- Stream-time: one content read at a time.
+
+---
+
+## 6. Trade-offs and known limits
+
+- **Pre-stream latency** is paid on every resume; HEAD-only build keeps it to single-digit seconds even for huge datasets. Manifest caching is a future option.
+- **Tab lifecycle:** pause/resume in the download manager works; closing the browser entirely is browser-specific. Power users use `curl -C -`.
+- **Selection cap:** 1000 fileIds per URL; whole-dataset URL has no cap.
+- **No intra-stream parallelism:** single serial stream by design.
+- **Resume identity:** changes to file set, ordering, content ETag, or `pemChecksum` invalidate resume (clean 200). Header byte drift does not.
+- **Header length stability** is the only load-bearing backend assumption; violation is detected and surfaced as 502.
+
+---
+
+## 7. Comparison with the other options
+
+```mermaid
+flowchart TB
+    Q1{Selection size?} -- "30-50 files" --> C[Option C: per-file clicks]
+    Q1 -- "large / full" --> Q2{Unattended<br/>hours or days?}
+    Q2 -- yes --> A[Option A: sda-cli]
+    Q2 -- no --> Q3{Install allowed?}
+    Q3 -- yes --> T["This proposal:<br/>TAR route"]
+    Q3 -- no --> Bopt[Option B: browser-only]
+```
+
+| Aspect                     | This proposal (TAR)             | Option A (sda-cli)       | Option B (browser)            | Option C (per-file clicks) |
+| -------------------------- | ------------------------------- | ------------------------ | ----------------------------- | -------------------------- |
+| Best for                   | Full dataset / large selection  | Full dataset, unattended | Full dataset, no install      | 30–50 files                |
+| Install required           | None                            | `sda-cli`                | None                          | None                       |
+| Output                     | One `.tar`                      | Native folder tree       | Folder (Chromium) / `.zip`    | Files in Downloads         |
+| Folder structure preserved | Yes (inside TAR)                | Yes                      | Yes                           | No                         |
+| Whole-archive resume       | Yes                             | n/a                      | No                            | n/a                        |
+| Tab lifecycle              | Pause/resume OK; close brittle  | Browser can close        | Tab must stay open            | Tab must stay open         |
+| Multi-day unattended       | No                              | Yes                      | No                            | No                         |
+| New backend deps           | None                            | None                     | None                          | Service Worker             |
+
+The TAR route's sweet spot: a few hundred to a few thousand files, one resumable download, zero install.
+
+---
+
+## 8. UI integration
+
+Both entry points are plain `<a download>` anchors — no client-side download machinery.
+
+```mermaid
+flowchart LR
+    subgraph DatasetDetails
+        BD["Download dataset"]
+    end
+    subgraph DatasetFiles
+        BS["Download selected as TAR"]
+    end
+    BD --> URL1["/api/datasets/&#123;id&#125;/download.tar"]
+    BS --> URL2["/api/datasets/&#123;id&#125;/download.tar?fileIds=…"]
+```
+
+Both buttons disabled with explanatory `title` when no public key is configured. Selection button disabled when 0 or >1000 selected.
+
+Docs/tooltips should mention browser pause/resume, `curl -C -` for power users, and the `sda-cli` path for huge unattended transfers.
+
+---
+
+## 9. Backend prerequisites
+
+| Requirement                                       | Status                  |
+| ------------------------------------------------- | ----------------------- |
+| Per-file `/header` and `/content`                 | already used            |
+| `Range` + `ETag` on `/content`                    | spec                    |
+| Stable `Content-Length` on `/header` per (id,key) | assumed; spec-conformant|
+| `HEAD /header` with the recipient key             | required                |
+| New persistent state                              | none                    |
+| New auth surface                                  | none                    |
+| Service Worker                                    | not used                |
+
+---
+
+## 10. Recommendation
+
+**Short term:** TAR route as the default "Download dataset" / "Download selected" action. Option C remains the right tool for small-batch native-file UX. Option A documented and linked for unattended multi-day workflows.
+
+**Long term:** consider caching manifests by `(datasetId, pemChecksum, fileIdSetHash)`; revisit Option B if browser capabilities improve; keep the per-file proxy as the foundation.
+
+---
+
+## 11. Open questions
+
+1. Pre-stream UX for multi-second manifest builds — spinner or explicit progress?
+2. Right concurrency cap (32 today)? Per-user limiting?
+3. Cache manifests server-side, or accept the per-resume cost?
+4. Dedicated docs page for power-user resume workflows?


### PR DESCRIPTION
This PR closes #65 .

After having a discussion and also adding another document with detailed description about another implementation. I am opening the PR again. My suggestion is to keep these documents under `/docs` until we have a better solution where to place them.