### PR TITLE
Make information box viewing x of x less prominent

### DIFF
--- a/frontend/src/app/(pages)/datasets/[datasetId]/page.tsx
+++ b/frontend/src/app/(pages)/datasets/[datasetId]/page.tsx
@@ -72,7 +72,7 @@ export default async function DatasetDetailsView({
               <DatasetDetails dataset={dataset} />
               <div className="container mt-5 px-0">
                 <h3>Files</h3>
-                <DatasetFiles files={files} />
+                <DatasetFiles files={files} itemsPerPage={10} />
               </div>
             </>
           )}

--- a/frontend/src/app/components/DatasetFiles.tsx
+++ b/frontend/src/app/components/DatasetFiles.tsx
@@ -7,7 +7,7 @@ import { Table } from "./Table";
 
 type DatasetFilesProps = {
   files: DatasetFile[];
-  itemsPerPage?: number;
+  itemsPerPage: number;
 };
 
 export default function DatasetFiles({

--- a/frontend/src/app/components/DatasetsList.tsx
+++ b/frontend/src/app/components/DatasetsList.tsx
@@ -6,7 +6,7 @@ import type { DatasetMetadata } from "../actions/datasets";
 
 type DatasetsListProps = {
   datasets: DatasetMetadata[];
-  itemsPerPage?: number;
+  itemsPerPage: number;
 };
 
 export default function DatasetsList({
@@ -76,28 +76,13 @@ export default function DatasetsList({
           onChange={handleSearchChange}
         />
       </div>
-      {filteredDatasets.length > 0 && (
-        <div className="col-12 mb-3">
-          <div className="d-flex justify-content-between align-items-center px-3 py-2 border border-info-subtle bg-info-subtle rounded ">
-            <span className="text-body-secondary">
-              Viewing{" "}
-              <strong>
-                {startItem}-{endItem}
-              </strong>{" "}
-              of <strong>{filteredDatasets.length}</strong>
-            </span>
-            <span className="text-muted fw-light">
-              Total of {datasets.length} datasets
-            </span>
-          </div>
-        </div>
-      )}
-
       {totalPages > 1 && (
         <Pagination
           currentPage={currentPage}
           totalPages={totalPages}
           onPageChange={setCurrentPage}
+          totalItems={filteredDatasets.length}
+          itemsPerPage={itemsPerPage}
         />
       )}
 
@@ -148,6 +133,8 @@ export default function DatasetsList({
           currentPage={currentPage}
           totalPages={totalPages}
           onPageChange={setCurrentPage}
+          totalItems={filteredDatasets.length}
+          itemsPerPage={itemsPerPage}
         />
       )}
     </>

--- a/frontend/src/app/components/Pagination.tsx
+++ b/frontend/src/app/components/Pagination.tsx
@@ -64,7 +64,7 @@ export default function Pagination({
   let startItem;
   let endItem;
 
-  if (itemsPerPage && totalItems) {
+  if (shouldShowViewingSummary) {
     startItem = totalItems === 0 ? 0 : (currentPage - 1) * itemsPerPage + 1;
     endItem = Math.min(currentPage * itemsPerPage, totalItems);
   }

--- a/frontend/src/app/components/Pagination.tsx
+++ b/frontend/src/app/components/Pagination.tsx
@@ -15,7 +15,12 @@ export default function Pagination({
   totalPages,
   onPageChange,
 }: PaginationProps) {
-  if (totalPages <= 1) {
+  const shouldShowPagination = totalPages > 1;
+  const shouldShowViewingSummary =
+      typeof itemsPerPage === "number" &&
+      typeof totalItems === "number";
+
+  if (!shouldShowPagination && !shouldShowViewingSummary) {
     return null;
   }
 
@@ -68,76 +73,81 @@ export default function Pagination({
   return (
     <nav aria-label="Pagination">
       <ul className="pagination flex-wrap">
-        <li className={`page-item ${isFirstPage ? "disabled" : ""}`}>
-          <button
-            type="button"
-            className="page-link"
-            onClick={() => onPageChange(1)}
-            disabled={isFirstPage}
-          >
-            <span className="d-inline d-sm-none">&lt;&lt;</span>
-            <span className="d-none d-sm-inline">First</span>
-          </button>
-        </li>
+        {shouldShowPagination && (
+            <>
+              <li className={`page-item ${isFirstPage ? "disabled" : ""}`}>
+                <button
+                    type="button"
+                    className="page-link"
+                    onClick={() => onPageChange(1)}
+                    disabled={isFirstPage}
+                >
+                  <span className="d-inline d-sm-none">&lt;&lt;</span>
+                  <span className="d-none d-sm-inline">First</span>
+                </button>
+              </li>
 
-        <li className={`page-item ${isFirstPage ? "disabled" : ""}`}>
-          <button
-            type="button"
-            className="page-link"
-            onClick={() => onPageChange(currentPage - 1)}
-            disabled={isFirstPage}
-          >
-            <span className="d-inline d-sm-none">&lt;</span>
-            <span className="d-none d-sm-inline">Previous</span>
-          </button>
-        </li>
-        {visibleItems.map((item) =>
-          typeof item === "number" ? (
-            <li
-              key={item}
-              className={`page-item ${item === currentPage ? "active" : ""}`}
-              aria-current={item === currentPage ? "page" : undefined}
-            >
-              <button
-                type="button"
-                className="page-link"
-                onClick={() => onPageChange(item)}
-                aria-label={`Go to page ${item}`}
-              >
-                {item}
-              </button>
-            </li>
-          ) : (
-            <li key={item} className="page-item disabled" aria-hidden="true">
-              <span className="page-link">…</span>
-            </li>
-          ),
+              <li className={`page-item ${isFirstPage ? "disabled" : ""}`}>
+                <button
+                    type="button"
+                    className="page-link"
+                    onClick={() => onPageChange(currentPage - 1)}
+                    disabled={isFirstPage}
+                >
+                  <span className="d-inline d-sm-none">&lt;</span>
+                  <span className="d-none d-sm-inline">Previous</span>
+                </button>
+              </li>
+              {visibleItems.map((item) =>
+                  typeof item === "number" ? (
+                      <li
+                          key={item}
+                          className={`page-item ${item === currentPage ? "active" : ""}`}
+                          aria-current={item === currentPage ? "page" : undefined}
+                      >
+                        <button
+                            type="button"
+                            className="page-link"
+                            onClick={() => onPageChange(item)}
+                            aria-label={`Go to page ${item}`}
+                        >
+                          {item}
+                        </button>
+                      </li>
+                  ) : (
+                      <li key={item} className="page-item disabled" aria-hidden="true">
+                        <span className="page-link">…</span>
+                      </li>
+                  ),
+              )}
+
+              <li className={`page-item ${isLastPage ? "disabled" : ""}`}>
+                <button
+                    type="button"
+                    className="page-link"
+                    onClick={() => onPageChange(currentPage + 1)}
+                    disabled={isLastPage}
+                >
+                  <span className="d-inline d-sm-none">&gt;</span>
+                  <span className="d-none d-sm-inline">Next</span>
+                </button>
+              </li>
+
+              <li className={`page-item ${isLastPage ? "disabled" : ""}`}>
+                <button
+                    type="button"
+                    className="page-link"
+                    onClick={() => onPageChange(totalPages)}
+                    disabled={isLastPage}
+                >
+                  <span className="d-inline d-sm-none">&gt;&gt;</span>
+                  <span className="d-none d-sm-inline">Last</span>
+                </button>
+              </li>
+            </>
         )}
 
-        <li className={`page-item ${isLastPage ? "disabled" : ""}`}>
-          <button
-            type="button"
-            className="page-link"
-            onClick={() => onPageChange(currentPage + 1)}
-            disabled={isLastPage}
-          >
-            <span className="d-inline d-sm-none">&gt;</span>
-            <span className="d-none d-sm-inline">Next</span>
-          </button>
-        </li>
-
-        <li className={`page-item ${isLastPage ? "disabled" : ""}`}>
-          <button
-            type="button"
-            className="page-link"
-            onClick={() => onPageChange(totalPages)}
-            disabled={isLastPage}
-          >
-            <span className="d-inline d-sm-none">&gt;&gt;</span>
-            <span className="d-none d-sm-inline">Last</span>
-          </button>
-        </li>
-        {itemsPerPage && totalItems && (
+        {shouldShowViewingSummary && (
           <li className="ms-3 ms-lg-4 my-3 my-lg-0 align-self-center">
             Viewing{" "}
             <strong>

--- a/frontend/src/app/components/Pagination.tsx
+++ b/frontend/src/app/components/Pagination.tsx
@@ -5,7 +5,7 @@ type PaginationProps = {
   totalItems?: number;
   currentPage: number;
   totalPages: number;
-  onPageChange: (page: number | string) => void;
+  onPageChange: (page: number) => void;
 };
 
 export default function Pagination({
@@ -17,8 +17,7 @@ export default function Pagination({
 }: PaginationProps) {
   const shouldShowPagination = totalPages > 1;
   const shouldShowViewingSummary =
-      typeof itemsPerPage === "number" &&
-      typeof totalItems === "number";
+    typeof itemsPerPage === "number" && typeof totalItems === "number";
 
   if (!shouldShowPagination && !shouldShowViewingSummary) {
     return null;
@@ -74,81 +73,87 @@ export default function Pagination({
     <nav aria-label="Pagination">
       <ul className="pagination flex-wrap">
         {shouldShowPagination && (
-            <>
-              <li className={`page-item ${isFirstPage ? "disabled" : ""}`}>
-                <button
-                    type="button"
-                    className="page-link"
-                    onClick={() => onPageChange(1)}
-                    disabled={isFirstPage}
-                >
-                  <span className="d-inline d-sm-none">&lt;&lt;</span>
-                  <span className="d-none d-sm-inline">First</span>
-                </button>
-              </li>
+          <>
+            <li className={`page-item ${isFirstPage ? "disabled" : ""}`}>
+              <button
+                type="button"
+                className="page-link"
+                onClick={() => onPageChange(1)}
+                disabled={isFirstPage}
+              >
+                <span className="d-inline d-sm-none">&lt;&lt;</span>
+                <span className="d-none d-sm-inline">First</span>
+              </button>
+            </li>
 
-              <li className={`page-item ${isFirstPage ? "disabled" : ""}`}>
-                <button
+            <li className={`page-item ${isFirstPage ? "disabled" : ""}`}>
+              <button
+                type="button"
+                className="page-link"
+                onClick={() => onPageChange(currentPage - 1)}
+                disabled={isFirstPage}
+              >
+                <span className="d-inline d-sm-none">&lt;</span>
+                <span className="d-none d-sm-inline">Previous</span>
+              </button>
+            </li>
+            {visibleItems.map((item) =>
+              typeof item === "number" ? (
+                <li
+                  key={item}
+                  className={`page-item ${item === currentPage ? "active" : ""}`}
+                  aria-current={item === currentPage ? "page" : undefined}
+                >
+                  <button
                     type="button"
                     className="page-link"
-                    onClick={() => onPageChange(currentPage - 1)}
-                    disabled={isFirstPage}
+                    onClick={() => onPageChange(item)}
+                    aria-label={`Go to page ${item}`}
+                  >
+                    {item}
+                  </button>
+                </li>
+              ) : (
+                <li
+                  key={item}
+                  className="page-item disabled"
+                  aria-hidden="true"
                 >
-                  <span className="d-inline d-sm-none">&lt;</span>
-                  <span className="d-none d-sm-inline">Previous</span>
-                </button>
-              </li>
-              {visibleItems.map((item) =>
-                  typeof item === "number" ? (
-                      <li
-                          key={item}
-                          className={`page-item ${item === currentPage ? "active" : ""}`}
-                          aria-current={item === currentPage ? "page" : undefined}
-                      >
-                        <button
-                            type="button"
-                            className="page-link"
-                            onClick={() => onPageChange(item)}
-                            aria-label={`Go to page ${item}`}
-                        >
-                          {item}
-                        </button>
-                      </li>
-                  ) : (
-                      <li key={item} className="page-item disabled" aria-hidden="true">
-                        <span className="page-link">…</span>
-                      </li>
-                  ),
-              )}
+                  <span className="page-link">…</span>
+                </li>
+              ),
+            )}
 
-              <li className={`page-item ${isLastPage ? "disabled" : ""}`}>
-                <button
-                    type="button"
-                    className="page-link"
-                    onClick={() => onPageChange(currentPage + 1)}
-                    disabled={isLastPage}
-                >
-                  <span className="d-inline d-sm-none">&gt;</span>
-                  <span className="d-none d-sm-inline">Next</span>
-                </button>
-              </li>
+            <li className={`page-item ${isLastPage ? "disabled" : ""}`}>
+              <button
+                type="button"
+                className="page-link"
+                onClick={() => onPageChange(currentPage + 1)}
+                disabled={isLastPage}
+              >
+                <span className="d-inline d-sm-none">&gt;</span>
+                <span className="d-none d-sm-inline">Next</span>
+              </button>
+            </li>
 
-              <li className={`page-item ${isLastPage ? "disabled" : ""}`}>
-                <button
-                    type="button"
-                    className="page-link"
-                    onClick={() => onPageChange(totalPages)}
-                    disabled={isLastPage}
-                >
-                  <span className="d-inline d-sm-none">&gt;&gt;</span>
-                  <span className="d-none d-sm-inline">Last</span>
-                </button>
-              </li>
-            </>
+            <li
+              className={`page-item me-lg-4 me-3 ${isLastPage ? "disabled" : ""}`}
+            >
+              <button
+                type="button"
+                className="page-link"
+                onClick={() => onPageChange(totalPages)}
+                disabled={isLastPage}
+              >
+                <span className="d-inline d-sm-none">&gt;&gt;</span>
+                <span className="d-none d-sm-inline ">Last</span>
+              </button>
+            </li>
+          </>
         )}
 
         {shouldShowViewingSummary && (
-          <li className="ms-3 ms-lg-4 my-3 my-lg-0 align-self-center">
+          <li className="my-3 my-lg-0 align-self-center">
             Viewing{" "}
             <strong>
               {startItem}-{endItem}


### PR DESCRIPTION


## Related issue(s) and PR(s)

This PR closes #67 and #75.

The viewing information was a little bit different between the Datasets and the datasets files list.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## List of changes made

- Made some refactoring to make the Pagination more clear by adding some bools like shouldShowPagination and shouldShowViewingSummary
- Let the viewing information be present even if there is no pagination so viewing x of x files
- TypeScript errors (which also fixes the production built error found in #75 

## Screenshot of the fix


<img width="1319" height="232" alt="Screenshot from 2026-05-08 14-08-27" src="https://github.com/user-attachments/assets/87c948de-8e26-4222-a073-c5ba17a58f16" />

<img width="1319" height="232" alt="Screenshot from 2026-05-08 14-08-18" src="https://github.com/user-attachments/assets/d3491789-4454-4c38-9418-40a9e432e16a" />

With no pagination:
<img width="1319" height="232" alt="Screenshot from 2026-05-08 14-08-38" src="https://github.com/user-attachments/assets/5c40c438-613d-41ce-b96a-10eeb327120f" />

## Testing

Test for different screen sizes, explorative testing.
Make sure production builds.

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any
- [x] All Acceptance Criteria (AC) Fulfilled and checked in the Related issue
