### PR TITLE
48 display file size unit on datasets page

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ environment consists of a compose file for starting a minimal sda
 development stack and the compose file for deploying the download UI
 webapp.
 
-### SDA development stack
+### Documentation References
+
+For calculating the file size we use the npm library [filesize](https://www.npmjs.com/package/filesize).
+
+#### SDA development stack
 
 The necessary configuration and compose files for starting the
 development stack for the `sda` backend services can be found under

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "bootstrap": "^5.3.8",
         "bootstrap-icons": "^1.13.1",
+        "filesize": "^11.0.17",
         "jose": "^6.2.2",
         "next": "16.2.3",
         "react": "19.2.4",
@@ -4161,6 +4162,15 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/filesize": {
+      "version": "11.0.17",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-11.0.17.tgz",
+      "integrity": "sha512-oHLTvMLw6imZUl1se/RBQrFlyy50nXce4sU7yGR6Qc0JgCwqnfiFsAnEwotdGmfKLD7SArGUk2/5STU0k8LOBQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 10.8.0"
       }
     },
     "node_modules/fill-range": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "bootstrap": "^5.3.8",
     "bootstrap-icons": "^1.13.1",
+    "filesize": "^11.0.17",
     "jose": "^6.2.2",
     "next": "16.2.3",
     "react": "19.2.4",

--- a/frontend/src/app/components/DatasetFiles.tsx
+++ b/frontend/src/app/components/DatasetFiles.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from "react";
 import { type DatasetFile } from "../actions/datasets";
 import Pagination from "./Pagination";
 import { Table } from "./Table";
+import { filesize } from "filesize";
 
 type DatasetFilesProps = {
   files: DatasetFile[];
@@ -20,7 +21,7 @@ export default function DatasetFiles({
   const formattedFiles = files.map((file) => ({
     fileId: file.fileId,
     filePath: file.filePath,
-    decryptedSize: file.decryptedSize,
+    decryptedSize: filesize(file.decryptedSize),
     checksums: file.checksums.map((c) => (
       <span key={c.checksum}>
         <i>{c.type}:</i> {c.checksum}

--- a/frontend/src/app/components/DatasetsList.tsx
+++ b/frontend/src/app/components/DatasetsList.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import Pagination from "@/app/components/Pagination";
 import type { DatasetMetadata } from "../actions/datasets";
 import Alert from "@/app/components/Alert";
+import { filesize } from "filesize";
 
 type DatasetsListProps = {
   datasets: DatasetMetadata[];
@@ -115,7 +116,7 @@ export default function DatasetsList({
                     <i className="bi bi-calendar pe-1"></i>Created{" "}
                     {new Date(dataset.date).toLocaleDateString("sv-SE")}
                   </span>
-                  <span>{dataset.size} bytes</span>
+                  <span>{filesize(dataset.size)}</span>
                 </div>
                 <div className="text-left">
                   <a

--- a/frontend/src/app/components/DatasetsList.tsx
+++ b/frontend/src/app/components/DatasetsList.tsx
@@ -50,10 +50,6 @@ export default function DatasetsList({
     return filteredDatasets.slice(startIndex, endIndex);
   }, [filteredDatasets, currentPage, itemsPerPage]);
 
-  const startItem =
-    filteredDatasets.length === 0 ? 0 : (currentPage - 1) * itemsPerPage + 1;
-  const endItem = Math.min(currentPage * itemsPerPage, filteredDatasets.length);
-
   function handleSearchChange(event: React.ChangeEvent<HTMLInputElement>) {
     setSearchTerm(event.target.value);
     setCurrentPage(1);


### PR DESCRIPTION
## Related issue

This PR closes #48 and suggests to display bytes in a more user friendly way. 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## List of changes made

- Installed the library [filesize](https://www.npmjs.com/package/filesize) from npm
- Used it with its defaults in datasets and files list
- Added a link to the library in the read me

## Screenshot of the fix

Datasets:
<img width="3418" height="1502" alt="Screenshot from 2026-05-13 10-26-36" src="https://github.com/user-attachments/assets/f5905825-348c-43cd-a978-e9d0a1a46b0e" />

List of files:
<img width="3418" height="1340" alt="image" src="https://github.com/user-attachments/assets/2a28c75e-4d1e-474e-937a-7b370b6e481b" />

## Further comments

The issue pointed out to use a comma for the decimal but I left it as the default with the point because I think that that would be more common in an European setting. The library provides different options so this could be changed.

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any
- [x] All Acceptance Criteria (AC) Fulfilled and checked in the Related issue

- [x] **Documentation Updated (if applicable):**
  - Relevant documentation is current.
  - Considerations: in-code comments, generated documentation, README files, Swagger docs, Postman collections, Confluence pages, etc.
