### PR TITLE
feat: add clipboard copy button for file checksums

### DIFF
--- a/frontend/src/app/components/ClipboardValue.tsx
+++ b/frontend/src/app/components/ClipboardValue.tsx
@@ -1,0 +1,28 @@
+import { useCallback, useState } from "react";
+
+export function ClipboardValue({
+  value,
+  icon,
+  copiedIcon,
+  label,
+}: {
+  value: string;
+  icon?: string;
+  copiedIcon?: string;
+  label?: string;
+}) {
+  const [isCopied, setIsCopied] = useState(false);
+  const copyToClipboard = useCallback(async () => {
+    await navigator.clipboard.writeText(value);
+    setIsCopied(true);
+  }, [value, setIsCopied]);
+  copiedIcon = copiedIcon || "clipboard-check";
+  icon = icon || "clipboard";
+  icon = isCopied ? copiedIcon : icon;
+  return (
+    <span onClick={copyToClipboard} className="mx-1" role="button">
+      {label ? <em>{label}</em> : <></>}
+      <i className={`bi bi-${icon} ps-1`}></i>
+    </span>
+  );
+}

--- a/frontend/src/app/components/DatasetFiles.tsx
+++ b/frontend/src/app/components/DatasetFiles.tsx
@@ -5,6 +5,7 @@ import { type DatasetFile } from "../actions/datasets";
 import Pagination from "./Pagination";
 import { Table } from "./Table";
 import { filesize } from "filesize";
+import { ClipboardValue } from "./ClipboardValue";
 
 type DatasetFilesProps = {
   files: DatasetFile[];
@@ -23,9 +24,7 @@ export default function DatasetFiles({
     filePath: file.filePath,
     decryptedSize: filesize(file.decryptedSize),
     checksums: file.checksums.map((c) => (
-      <span key={c.checksum}>
-        <i>{c.type}:</i> {c.checksum}
-      </span>
+      <ClipboardValue key={c.checksum} value={c.checksum} label={c.type} />
     )),
 
     downloadUrl: <a href={file.downloadUrl}>Download file</a>,


### PR DESCRIPTION
<!-- Remove sections from this template that are not used -->

## Related issue(s) and PR(s)

This PR closes #73 

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change

<!-- Please delete options that are not relevant -->

- [x] New feature (non-breaking change which adds functionality)

## List of changes made

- Add new component `ClipboardValue` which provide a labeled button which copies a string value to the clipboard
- Use `ClipboardValue` component instead of whole checksums in file listing

## Screenshot of the fix

<img width="828" height="1017" alt="Screen Shot 2026-05-13 at 17 08 54" src="https://github.com/user-attachments/assets/46ff0dfc-1c7a-4144-a62e-0ec788a66753" />


## Testing

- Start the development stack
- Sign in
- Go to: http://localhost:3002/datasets and select a dataset
- Copy some of the checksums using the copy to clipboard button

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any
- [x] All Acceptance Criteria (AC) Fulfilled and checked in the Related issue

- [ ] **Documentation Updated (if applicable):**
  - Relevant documentation is current.
  - Considerations: in-code comments, generated documentation, README files, Swagger docs, Postman collections, Confluence pages, etc.
- [ ] **Follow-up Backlog Items Created (if applicable):**
  - Necessary follow-up tasks have been identified and added to the backlog.
  - Considerations: next iteration tasks, performance enhancements, visual improvements, refactoring needs, addressing technical debt.
