### PR TITLE
Single file download

### DIFF
--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -172,6 +172,16 @@ The stack is pre-seeded with:
 
 The mock OIDC token for `integration_test@example.org` includes visas for datasets `EGAD00000000001` through `EGAD00000000110`.
 
+### Optional: seed large file
+
+Sometimes it may be useful to include a large file into a dataset for testing e.g. partial downloads and resuming functionality. To achive this include the `seed-large-file` profile in the docker compose command. For example:
+
+```bash
+docker compose -f sda-dev-stack.yml --profile seed-large-file up -d
+```
+
+This will include a 2 GB file in dataset `EGAD00000000002`.
+
 ## Cleanup
 
 ``` bash

--- a/dev-tools/sda-dev-stack.yml
+++ b/dev-tools/sda-dev-stack.yml
@@ -171,6 +171,28 @@ services:
       - ./seed.sh:/seed.sh:ro
       - shared:/shared
 
+  seed-large-file:
+    extends:
+      service: seed
+    profiles: ["seed-large-file"]
+    depends_on:
+      seed:
+        condition: service_completed_successfully
+    command:
+      - /bin/sh
+      - -c
+      - |
+        apt-get -o DPkg::Lock::Timeout=60 update > /dev/null
+        apt-get -o DPkg::Lock::Timeout=60 install -y curl postgresql-client > /dev/null
+        pip install --upgrade pip > /dev/null
+        pip install crypt4gh > /dev/null
+        curl -sL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc
+        chmod +x /usr/local/bin/mc
+        sh /seed-large-file.sh
+    volumes:
+      - ./seed-large-file.sh:/seed-large-file.sh:ro
+      - shared:/shared
+
   # Mock OIDC server with /tokens endpoint for easy token retrieval
   mockauth:
     command:

--- a/dev-tools/seed-large-file.sh
+++ b/dev-tools/seed-large-file.sh
@@ -1,0 +1,134 @@
+#!/bin/sh
+# Adds a single 2 GiB file to dataset EGAD00000000002.
+# Run inside the same seed container (needs crypt4gh, mc, psql, python3,
+# and access to /shared/c4gh.pub.pem).
+set -e
+
+LARGE_MARKER="/shared/.large_file_seeded"
+if [ -f "$LARGE_MARKER" ]; then
+  echo "Large file already seeded, skipping."
+  exit 0
+fi
+
+FILE_STABLE_ID="EGAF00000000999"
+FILE_UUID="aaaaaaaa-bbbb-cccc-dddd-000000000999"
+FILE_NAME="large-file-2gb.c4gh"
+DATASET_STABLE_ID="EGAD00000000002"
+SUBMISSION_USER="integration_test@example.org"
+
+PLAINTEXT=/tmp/large_plaintext.bin
+ENCRYPTED=/tmp/large_encrypted.c4gh
+
+# Create 2 GiB of deterministic plaintext (fast: sparse-ish, but we need real bytes for c4gh)
+# Use /dev/zero so encryption is quick and reproducible.
+echo "Generating 2 GiB plaintext..."
+dd if=/dev/zero of="$PLAINTEXT" bs=1M count=2048 status=none
+
+echo "Encrypting with crypt4gh..."
+crypt4gh encrypt --recipient_pk /shared/c4gh.pub.pem < "$PLAINTEXT" > "$ENCRYPTED"
+
+echo "Splitting header/body and computing checksums..."
+python3 << 'PYEOF'
+import struct, hashlib
+
+with open("/tmp/large_encrypted.c4gh", "rb") as f:
+    # Read header first
+    magic = f.read(8)
+    assert magic == b"crypt4gh", f"Bad magic: {magic}"
+    version = f.read(4)
+    packet_count = struct.unpack("<I", f.read(4))[0]
+    header = magic + version + struct.pack("<I", packet_count)
+    for _ in range(packet_count):
+        pkt_len_bytes = f.read(4)
+        pkt_len = struct.unpack("<I", pkt_len_bytes)[0]
+        rest = f.read(pkt_len - 4)
+        header += pkt_len_bytes + rest
+
+    with open("/tmp/large_header.bin", "wb") as h:
+        h.write(header)
+
+    # Stream body to file while computing sha256
+    body_sha = hashlib.sha256()
+    body_size = 0
+    with open("/tmp/large_body.bin", "wb") as b:
+        while True:
+            chunk = f.read(8 * 1024 * 1024)
+            if not chunk:
+                break
+            b.write(chunk)
+            body_sha.update(chunk)
+            body_size += len(chunk)
+
+# Plaintext checksum (stream)
+pt_sha = hashlib.sha256()
+pt_size = 0
+with open("/tmp/large_plaintext.bin", "rb") as p:
+    while True:
+        chunk = p.read(8 * 1024 * 1024)
+        if not chunk:
+            break
+        pt_sha.update(chunk)
+        pt_size += len(chunk)
+
+with open("/tmp/large_seed_metadata.env", "w") as f:
+    f.write(f"HEADER_HEX={header.hex()}\n")
+    f.write(f"ARCHIVE_SIZE={body_size}\n")
+    f.write(f"DECRYPTED_SIZE={pt_size}\n")
+    f.write(f"ARCHIVE_CHECKSUM={body_sha.hexdigest()}\n")
+    f.write(f"DECRYPTED_CHECKSUM={pt_sha.hexdigest()}\n")
+
+print(f"Header: {len(header)} bytes, Body: {body_size} bytes, Plaintext: {pt_size} bytes")
+PYEOF
+
+. /tmp/large_seed_metadata.env
+
+echo "Uploading to MinIO..."
+mc alias set myminio http://s3:9000 access secretKey --quiet
+mc mb myminio/archive --ignore-existing --quiet
+mc pipe "myminio/archive/$FILE_NAME" < /tmp/large_body.bin
+
+echo "Inserting DB rows..."
+pg_isready -h postgres -p 5432 -U postgres
+
+psql -h postgres -U postgres -d sda << EOSQL
+INSERT INTO sda.files (
+  id, stable_id, submission_user, submission_file_path,
+  archive_file_path, archive_location, archive_file_size, decrypted_file_size,
+  header, encryption_method
+) VALUES (
+  '$FILE_UUID',
+  '$FILE_STABLE_ID',
+  '$SUBMISSION_USER',
+  '$FILE_NAME',
+  '$FILE_NAME',
+  'http://s3:9000/archive',
+  $ARCHIVE_SIZE,
+  $DECRYPTED_SIZE,
+  '$HEADER_HEX',
+  'CRYPT4GH'
+) ON CONFLICT (id) DO UPDATE SET
+  stable_id = EXCLUDED.stable_id,
+  archive_file_size = EXCLUDED.archive_file_size,
+  decrypted_file_size = EXCLUDED.decrypted_file_size,
+  header = EXCLUDED.header,
+  archive_file_path = EXCLUDED.archive_file_path,
+  submission_file_path = EXCLUDED.submission_file_path;
+
+INSERT INTO sda.file_dataset (file_id, dataset_id)
+  SELECT '$FILE_UUID'::uuid, d.id
+  FROM sda.datasets d
+  WHERE d.stable_id = '$DATASET_STABLE_ID'
+  ON CONFLICT DO NOTHING;
+
+DELETE FROM sda.checksums WHERE file_id = '$FILE_UUID';
+INSERT INTO sda.checksums (file_id, checksum, type, source) VALUES
+  ('$FILE_UUID', '$ARCHIVE_CHECKSUM', 'SHA256', 'ARCHIVED'),
+  ('$FILE_UUID', '$DECRYPTED_CHECKSUM', 'SHA256', 'UNENCRYPTED');
+EOSQL
+
+# Cleanup big temp files
+rm -f "$PLAINTEXT" "$ENCRYPTED" /tmp/large_body.bin /tmp/large_header.bin
+
+echo "Added $FILE_STABLE_ID (2 GiB) to $DATASET_STABLE_ID"
+
+touch "$LARGE_MARKER"

--- a/frontend/src/app/(pages)/datasets/[datasetId]/page.tsx
+++ b/frontend/src/app/(pages)/datasets/[datasetId]/page.tsx
@@ -86,10 +86,9 @@ export default async function DatasetDetailsView({
                     iconClass="bi bi-exclamation-triangle-fill"
                     alertMessage={
                       <>
-                        You have not uploaded a Crypt4GH public key. File
-                        downloads will fail until you{" "}
+                        File download will be unavailable until you{" "}
                         <Link href="/userinfo">
-                          upload a public key on your profile page
+                          upload a Crypt4GH public key on your profile page
                         </Link>
                         .
                       </>

--- a/frontend/src/app/(pages)/datasets/[datasetId]/page.tsx
+++ b/frontend/src/app/(pages)/datasets/[datasetId]/page.tsx
@@ -9,6 +9,7 @@ import { getSession } from "@/app/lib/session";
 import DatasetDetails from "../../../components/DatasetDetails";
 import DatasetFiles from "@/app/components/DatasetFiles";
 import Alert from "@/app/components/Alert";
+import Link from "next/link";
 
 interface DatasetDetailsViewProps {
   params: Promise<{
@@ -23,6 +24,7 @@ export default async function DatasetDetailsView({
 
   const sessionData = await getSession();
   const token = sessionData?.token;
+  const hasPublicKey = !!sessionData?.publicKey?.key;
 
   let errorMessage: string | null = null;
   let dataset: DatasetMetadata | null = null;
@@ -78,7 +80,27 @@ export default async function DatasetDetailsView({
               <DatasetDetails dataset={dataset} />
               <div className="container mt-5 px-0">
                 <h3>Files</h3>
-                <DatasetFiles files={files} defaultItemsPerPage={15} />
+                {!hasPublicKey && (
+                  <Alert
+                    type="warning"
+                    iconClass="bi bi-exclamation-triangle-fill"
+                    alertMessage={
+                      <>
+                        You have not uploaded a Crypt4GH public key. File
+                        downloads will fail until you{" "}
+                        <Link href="/userinfo">
+                          upload a public key on your profile page
+                        </Link>
+                        .
+                      </>
+                    }
+                  />
+                )}
+                <DatasetFiles
+                  files={files}
+                  defaultItemsPerPage={10}
+                  canDownload={hasPublicKey}
+                />
               </div>
             </>
           )}

--- a/frontend/src/app/api/files/[fileId]/route.test.ts
+++ b/frontend/src/app/api/files/[fileId]/route.test.ts
@@ -314,36 +314,6 @@ describe("GET /api/files/[fileId]", () => {
     );
   });
 
-  // Resuming with range entirely inside the header
-
-  test("Range entirely inside the header → 206, no /content GET", async () => {
-    setSession(validSession);
-    const spy = installDispatchedFetch(defaultHandler);
-
-    const { request, params } = makeRequest("file-1", {
-      range: `bytes=10-${HEADER_LEN - 10}`,
-    });
-    const response = await GET(request, { params });
-
-    expect(response.status).toBe(206);
-    const expectedLen = HEADER_LEN - 10 - 10 + 1;
-    expect(response.headers.get("content-length")).toBe(String(expectedLen));
-    expect(response.headers.get("content-range")).toBe(
-      `bytes 10-${HEADER_LEN - 10}/${TOTAL_LEN}`,
-    );
-    expect(response.headers.get("etag")).toBe(ETAG);
-
-    const body = await readAll(response.body);
-    expect(body).toEqual(headerBody.subarray(10, HEADER_LEN - 10 + 1));
-
-    const getContent = spy.mock.calls.find(
-      ([url, init]) =>
-        String(url).endsWith("/content") &&
-        (init?.method || "GET").toUpperCase() === "GET",
-    );
-    expect(getContent).toBeUndefined();
-  });
-
   // Resuming with range entirely inside the content
 
   test("Range entirely inside the content → 206, no /header GET, translated Range", async () => {
@@ -384,33 +354,6 @@ describe("GET /api/files/[fileId]", () => {
     expect(sentRange).toBe("bytes=100-199");
   });
 
-  // Resuming with range spanning both header and content
-
-  test("Range spanning header/content boundary → stitched 206", async () => {
-    setSession(validSession);
-    installDispatchedFetch(defaultHandler);
-
-    const start = HEADER_LEN - 10;
-    const end = HEADER_LEN + 9;
-
-    const { request, params } = makeRequest("file-1", {
-      range: `bytes=${start}-${end}`,
-    });
-    const response = await GET(request, { params });
-
-    expect(response.status).toBe(206);
-    expect(response.headers.get("content-length")).toBe("20");
-    expect(response.headers.get("content-range")).toBe(
-      `bytes ${start}-${end}/${TOTAL_LEN}`,
-    );
-
-    const body = await readAll(response.body);
-    const expected = new Uint8Array(20);
-    expected.set(headerBody.subarray(HEADER_LEN - 10), 0);
-    expected.set(contentBody.subarray(0, 10), 10);
-    expect(body).toEqual(expected);
-  });
-
   // Resuming with open-ended range (partial file download with unknown total size)
 
   test("open-ended Range bytes=N- → 206 from N to end", async () => {
@@ -431,6 +374,57 @@ describe("GET /api/files/[fileId]", () => {
 
     const body = await readAll(response.body);
     expect(body).toEqual(contentBody.subarray(500));
+  });
+
+  // Header-overlapping ranges are refused and the proxy serves the full file
+  // instead. This protects against resumes that would splice a fresh
+  // re-encrypted header onto a stale one thus resulting in corrupted downloads.
+
+  test("Range spanning header/content boundary → 200 full file", async () => {
+    setSession(validSession);
+    installDispatchedFetch(defaultHandler);
+
+    const start = HEADER_LEN - 10;
+    const end = HEADER_LEN + 9;
+
+    const { request, params } = makeRequest("file-1", {
+      range: `bytes=${start}-${end}`,
+    });
+    const response = await GET(request, { params });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-length")).toBe(String(TOTAL_LEN));
+    expect(response.headers.get("content-range")).toBeNull();
+  });
+
+  test("Range starting exactly at headerLen with If-Range → 206, no /header GET", async () => {
+    setSession(validSession);
+    const spy = installDispatchedFetch(defaultHandler);
+
+    const start = HEADER_LEN;
+    const end = HEADER_LEN + 99;
+
+    const { request, params } = makeRequest("file-1", {
+      range: `bytes=${start}-${end}`,
+      ifRange: ETAG,
+    });
+    const response = await GET(request, { params });
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("content-length")).toBe("100");
+    expect(response.headers.get("content-range")).toBe(
+      `bytes ${start}-${end}/${TOTAL_LEN}`,
+    );
+
+    const body = await readAll(response.body);
+    expect(body).toEqual(contentBody.subarray(0, 100));
+
+    const getHeader = spy.mock.calls.find(
+      ([url, init]) =>
+        String(url).endsWith("/header") &&
+        (init?.method || "GET").toUpperCase() === "GET",
+    );
+    expect(getHeader).toBeUndefined();
   });
 
   // If-Range matching ETag should honor the Range, otherwise ignore it and return 200 with full body.
@@ -459,7 +453,7 @@ describe("GET /api/files/[fileId]", () => {
     installDispatchedFetch(defaultHandler);
 
     const { request, params } = makeRequest("file-1", {
-      range: "bytes=0-99",
+      range: `bytes=${HEADER_LEN + 50}-${HEADER_LEN + 99}`,
       ifRange: '"stale-etag"',
     });
     const response = await GET(request, { params });

--- a/frontend/src/app/api/files/[fileId]/route.test.ts
+++ b/frontend/src/app/api/files/[fileId]/route.test.ts
@@ -80,6 +80,8 @@ const HEADER_LEN = 124;
 const CONTENT_LEN = 1000;
 const TOTAL_LEN = HEADER_LEN + CONTENT_LEN;
 const ETAG = '"content-etag-abc"';
+const PEM_CHECKSUM = "checksum"; // matches validSession.publicKey.pemChecksum
+const EXPOSED_ETAG = `"content-etag-abc-${PEM_CHECKSUM}"`;
 
 // Fixed body fixtures so tests can assert on stitched output.
 const headerBody = new Uint8Array(HEADER_LEN).map((_, i) => (i + 1) % 256);
@@ -285,7 +287,7 @@ describe("GET /api/files/[fileId]", () => {
     );
     expect(response.headers.get("content-length")).toBe(String(TOTAL_LEN));
     expect(response.headers.get("accept-ranges")).toBe("bytes");
-    expect(response.headers.get("etag")).toBe(ETAG);
+    expect(response.headers.get("etag")).toBe(EXPOSED_ETAG);
     expect(response.headers.get("cache-control")).toBe("no-store");
     expect(response.headers.get("content-disposition")).toBe(
       "attachment; " +
@@ -406,7 +408,7 @@ describe("GET /api/files/[fileId]", () => {
 
     const { request, params } = makeRequest("file-1", {
       range: `bytes=${start}-${end}`,
-      ifRange: ETAG,
+      ifRange: EXPOSED_ETAG,
     });
     const response = await GET(request, { params });
 
@@ -438,7 +440,7 @@ describe("GET /api/files/[fileId]", () => {
 
     const { request, params } = makeRequest("file-1", {
       range: `bytes=${start}-${end}`,
-      ifRange: ETAG,
+      ifRange: EXPOSED_ETAG,
     });
     const response = await GET(request, { params });
 
@@ -590,5 +592,31 @@ describe("GET /api/files/[fileId]", () => {
       error: "Could not reach the download backend: Network error",
       status: 502,
     });
+  });
+
+  // Simulate a session where the user has just uploaded a new key.
+  // The browser is replaying the If-Range it captured from the previous
+  // download (when a different key was in use).
+  test("resume with old key's ETag after key swap → 200 full file", async () => {
+    setSession({
+      token: "my-token",
+      publicKey: { key: "NEW_PUBKEY", pemChecksum: "new-checksum" },
+    });
+    installDispatchedFetch(defaultHandler);
+
+    const oldExposedEtag = `"content-etag-abc-old-checksum"`;
+
+    const { request, params } = makeRequest("file-1", {
+      range: `bytes=${HEADER_LEN + 100}-${HEADER_LEN + 199}`,
+      ifRange: oldExposedEtag,
+    });
+    const response = await GET(request, { params });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-length")).toBe(String(TOTAL_LEN));
+    expect(response.headers.get("content-range")).toBeNull();
+    expect(response.headers.get("etag")).toBe(
+      `"content-etag-abc-new-checksum"`,
+    );
   });
 });

--- a/frontend/src/app/api/files/[fileId]/route.test.ts
+++ b/frontend/src/app/api/files/[fileId]/route.test.ts
@@ -83,9 +83,7 @@ const ETAG = '"content-etag-abc"';
 
 // Fixed body fixtures so tests can assert on stitched output.
 const headerBody = new Uint8Array(HEADER_LEN).map((_, i) => (i + 1) % 256);
-const contentBody = new Uint8Array(CONTENT_LEN).map(
-  (_, i) => (i + 200) % 256,
-);
+const contentBody = new Uint8Array(CONTENT_LEN).map((_, i) => (i + 200) % 256);
 
 type DispatchHandler = (
   url: string,
@@ -93,17 +91,15 @@ type DispatchHandler = (
 ) => Response | Promise<Response>;
 
 function installDispatchedFetch(handler: DispatchHandler) {
-  return vi
-    .spyOn(globalThis, "fetch")
-    .mockImplementation((input, init) => {
-      const url =
-        typeof input === "string"
-          ? input
-          : input instanceof URL
-            ? input.toString()
-            : (input as Request).url;
-      return Promise.resolve(handler(url, init));
-    });
+  return vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    return Promise.resolve(handler(url, init));
+  });
 }
 
 function headerHeadResponse() {
@@ -588,9 +584,7 @@ describe("GET /api/files/[fileId]", () => {
 
   test("returns 502 when the probe fetch itself fails", async () => {
     setSession(validSession);
-    vi.spyOn(globalThis, "fetch").mockRejectedValue(
-      new Error("Network error"),
-    );
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("Network error"));
 
     const { request, params } = makeRequest("file-1");
     const response = await GET(request, { params });

--- a/frontend/src/app/api/files/[fileId]/route.test.ts
+++ b/frontend/src/app/api/files/[fileId]/route.test.ts
@@ -1,0 +1,345 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from "vitest";
+import { GET } from "./route";
+import { NextRequest } from "next/server";
+import type { SessionData } from "@/app/lib/SessionManager";
+
+/**
+ * Unit tests for the file download proxy route.
+ *
+ * The route is exercised end-to-end by constructing a NextRequest and calling
+ * GET() directly. globalThis.fetch and the session/config modules are mocked
+ * so the tests run without a backend.
+ */
+
+const sdaBaseUrl = "http://test.local";
+
+vi.mock(import("next/server"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    connection: async () => {},
+  };
+});
+
+vi.mock(import("server-only"), () => {
+  return {};
+});
+
+vi.mock(import("@/app/lib/config"), () => {
+  return {
+    getConfig: async () => ({
+      sdaBaseUrl,
+      sessionSecretPath: "",
+    }),
+  };
+});
+
+// Mutable session result so each test can control what getSession returns.
+const sessionState: { current: SessionData | null } = { current: null };
+
+vi.mock(import("@/app/lib/session"), () => {
+  return {
+    getSession: async () => sessionState.current,
+    createOrUpdateSession: async () => undefined,
+    getClaims: async () => ({}),
+  };
+});
+
+function makeRequest(
+  fileId: string,
+  options: {
+    name?: string;
+    range?: string;
+    ifRange?: string;
+  } = {},
+) {
+  const url = new URL(`http://localhost/api/files/${fileId}`);
+  if (options.name) url.searchParams.set("name", options.name);
+
+  const headers = new Headers();
+  if (options.range) headers.set("range", options.range);
+  if (options.ifRange) headers.set("if-range", options.ifRange);
+
+  const request = new NextRequest(url, { headers });
+  const params = Promise.resolve({ fileId });
+
+  return { request, params };
+}
+
+function setSession(state: SessionData | null): SessionData | null {
+  sessionState.current = state;
+  return state;
+}
+
+const validSession: SessionData = {
+  token: "my-token",
+  publicKey: { key: "PUBKEY", pemChecksum: "checksum" },
+};
+
+describe("GET /api/files/[fileId]", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    sessionState.current = null;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("returns 401 when no session token is present", async () => {
+    setSession(null);
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const { request, params } = makeRequest("file-1");
+    const response = await GET(request, { params });
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("content-disposition")).toBeNull();
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Not authenticated.",
+      status: 401,
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 when session has no public key", async () => {
+    setSession({ token: "my-token", publicKey: null });
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const { request, params } = makeRequest("file-1");
+    const response = await GET(request, { params });
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("content-disposition")).toBeNull();
+    await expect(response.json()).resolves.toMatchObject({
+      status: 400,
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("calls upstream with Authorization, X-C4GH-Public-Key and forwards Range/If-Range", async () => {
+    setSession(validSession);
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("payload", {
+        status: 200,
+        headers: {
+          "content-type": "application/octet-stream",
+          "content-disposition": 'attachment; filename="upstream.c4gh"',
+        },
+      }),
+    );
+
+    const { request, params } = makeRequest("file-1", {
+      range: "bytes=0-1048575",
+      ifRange: '"etag-value"',
+    });
+    await GET(request, { params });
+
+    expect(fetchSpy).toHaveBeenCalledWith(`${sdaBaseUrl}/files/file-1`, {
+      headers: {
+        Authorization: "Bearer my-token",
+        "X-C4GH-Public-Key": "PUBKEY",
+        Range: "bytes=0-1048575",
+        "If-Range": '"etag-value"',
+      },
+      cache: "no-store",
+    });
+  });
+
+  test("forwards documented response headers and streams body on success", async () => {
+    setSession(validSession);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("payload", {
+        status: 200,
+        headers: {
+          "content-type": "application/octet-stream",
+          "content-length": "7",
+          "content-disposition": 'attachment; filename="upstream.c4gh"',
+          "accept-ranges": "bytes",
+          etag: '"abc123"',
+          "last-modified": "Wed, 01 Jan 2025 00:00:00 GMT",
+        },
+      }),
+    );
+
+    const { request, params } = makeRequest("file-1");
+    const response = await GET(request, { params });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "application/octet-stream",
+    );
+    expect(response.headers.get("content-length")).toBe("7");
+    expect(response.headers.get("content-disposition")).toBe(
+      'attachment; filename="upstream.c4gh"',
+    );
+    expect(response.headers.get("accept-ranges")).toBe("bytes");
+    expect(response.headers.get("etag")).toBe('"abc123"');
+    expect(response.headers.get("last-modified")).toBe(
+      "Wed, 01 Jan 2025 00:00:00 GMT",
+    );
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    await expect(response.text()).resolves.toBe("payload");
+  });
+
+  test("fallback Content-Disposition uses basename from name query param", async () => {
+    setSession(validSession);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("payload", {
+        status: 200,
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+
+    const { request, params } = makeRequest("file-1", {
+      name: "samples/controls/sample1.cram.c4gh",
+    });
+    const response = await GET(request, { params });
+
+    expect(response.headers.get("content-disposition")).toBe(
+      "attachment; " +
+        'filename="sample1.cram.c4gh"; ' +
+        "filename*=UTF-8''sample1.cram.c4gh",
+    );
+  });
+
+  test("fallback Content-Disposition uses <fileId>.c4gh when no name is given", async () => {
+    setSession(validSession);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("payload", {
+        status: 200,
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+
+    const { request, params } = makeRequest("file-1");
+    const response = await GET(request, { params });
+
+    expect(response.headers.get("content-disposition")).toBe(
+      "attachment; " +
+        'filename="file-1.c4gh"; ' +
+        "filename*=UTF-8''file-1.c4gh",
+    );
+  });
+
+  test.each([
+    {
+      name: "401 from upstream surfaces detail from problem+json",
+      status: 401,
+      body: { title: "Unauthorized", status: 401, detail: "Token expired." },
+      expectedDetail: "Token expired.",
+    },
+    {
+      name: "403 from upstream surfaces detail from problem+json",
+      status: 403,
+      body: {
+        title: "Forbidden",
+        status: 403,
+        detail: "You do not have access.",
+      },
+      expectedDetail: "You do not have access.",
+    },
+    {
+      name: "416 from upstream surfaces detail from problem+json",
+      status: 416,
+      body: {
+        title: "Range Not Satisfiable",
+        status: 416,
+        detail: "Out of range.",
+      },
+      expectedDetail: "Out of range.",
+    },
+    {
+      name: "500 from upstream surfaces detail from problem+json",
+      status: 500,
+      body: { title: "Internal Server Error", status: 500, detail: "Boom." },
+      expectedDetail: "Boom.",
+    },
+  ])("$name", async ({ status, body, expectedDetail }) => {
+    setSession(validSession);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/problem+json" },
+      }),
+    );
+
+    const { request, params } = makeRequest("file-1");
+    const response = await GET(request, { params });
+
+    expect(response.status).toBe(status);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("content-disposition")).toBeNull();
+    await expect(response.json()).resolves.toEqual({
+      error: expectedDetail,
+      status,
+    });
+  });
+
+  test.each([
+    {
+      name: "401 with non-JSON body uses 401 fallback message",
+      status: 401,
+      body: "not json",
+      expected:
+        "Authentication with the download backend failed. Please sign in again.",
+    },
+    {
+      name: "403 with non-JSON body uses 403 fallback message",
+      status: 403,
+      body: "not json",
+      expected: "You do not have access to this file (or it does not exist).",
+    },
+    {
+      name: "416 with non-JSON body uses 416 fallback message",
+      status: 416,
+      body: "not json",
+      expected: "The requested byte range is not satisfiable.",
+    },
+    {
+      name: "500 with non-JSON body uses generic fallback message",
+      status: 500,
+      body: "not json",
+      expected: "Download failed with status 500.",
+    },
+  ])("$name", async ({ status, body, expected }) => {
+    setSession(validSession);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(body, {
+        status,
+        headers: { "content-type": "text/plain" },
+      }),
+    );
+
+    const { request, params } = makeRequest("file-1");
+    const response = await GET(request, { params });
+
+    expect(response.status).toBe(status);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("content-disposition")).toBeNull();
+    await expect(response.json()).resolves.toEqual({
+      error: expected,
+      status,
+    });
+  });
+
+  test("returns 502 when fetch itself fails", async () => {
+    setSession(validSession);
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(
+      new Error("Network error"),
+    );
+
+    const { request, params } = makeRequest("file-1");
+    const response = await GET(request, { params });
+
+    expect(response.status).toBe(502);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("content-disposition")).toBeNull();
+    await expect(response.json()).resolves.toEqual({
+      error: "Could not reach the download backend: Network error",
+      status: 502,
+    });
+  });
+});

--- a/frontend/src/app/api/files/[fileId]/route.test.ts
+++ b/frontend/src/app/api/files/[fileId]/route.test.ts
@@ -76,6 +76,130 @@ const validSession: SessionData = {
   publicKey: { key: "PUBKEY", pemChecksum: "checksum" },
 };
 
+const HEADER_LEN = 124;
+const CONTENT_LEN = 1000;
+const TOTAL_LEN = HEADER_LEN + CONTENT_LEN;
+const ETAG = '"content-etag-abc"';
+
+// Fixed body fixtures so tests can assert on stitched output.
+const headerBody = new Uint8Array(HEADER_LEN).map((_, i) => (i + 1) % 256);
+const contentBody = new Uint8Array(CONTENT_LEN).map(
+  (_, i) => (i + 200) % 256,
+);
+
+type DispatchHandler = (
+  url: string,
+  init: RequestInit | undefined,
+) => Response | Promise<Response>;
+
+function installDispatchedFetch(handler: DispatchHandler) {
+  return vi
+    .spyOn(globalThis, "fetch")
+    .mockImplementation((input, init) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : (input as Request).url;
+      return Promise.resolve(handler(url, init));
+    });
+}
+
+function headerHeadResponse() {
+  return new Response(null, {
+    status: 200,
+    headers: { "content-length": String(HEADER_LEN) },
+  });
+}
+
+function contentHeadResponse() {
+  return new Response(null, {
+    status: 200,
+    headers: {
+      "content-length": String(CONTENT_LEN),
+      etag: ETAG,
+      "accept-ranges": "bytes",
+    },
+  });
+}
+
+function headerGetResponse() {
+  return new Response(headerBody, {
+    status: 200,
+    headers: { "content-length": String(HEADER_LEN) },
+  });
+}
+
+function contentGetResponse(range?: { start: number; end: number }) {
+  if (!range) {
+    return new Response(contentBody, {
+      status: 200,
+      headers: {
+        "content-length": String(CONTENT_LEN),
+        etag: ETAG,
+      },
+    });
+  }
+  const slice = contentBody.subarray(range.start, range.end + 1);
+  return new Response(slice, {
+    status: 206,
+    headers: {
+      "content-length": String(slice.byteLength),
+      "content-range": `bytes ${range.start}-${range.end}/${CONTENT_LEN}`,
+      etag: ETAG,
+    },
+  });
+}
+
+function defaultHandler(
+  url: string,
+  init: RequestInit | undefined,
+): Response | Promise<Response> {
+  const method = (init?.method || "GET").toUpperCase();
+
+  if (url.endsWith("/header") && method === "HEAD") return headerHeadResponse();
+  if (url.endsWith("/content") && method === "HEAD")
+    return contentHeadResponse();
+
+  if (url.endsWith("/header") && method === "GET") return headerGetResponse();
+
+  if (url.endsWith("/content") && method === "GET") {
+    const rangeHdr = new Headers(init?.headers).get("range");
+    if (rangeHdr) {
+      const m = rangeHdr.match(/^bytes=(\d+)-(\d+)$/);
+      if (m) {
+        return contentGetResponse({
+          start: parseInt(m[1], 10),
+          end: parseInt(m[2], 10),
+        });
+      }
+    }
+    return contentGetResponse();
+  }
+
+  return new Response("unmocked URL", { status: 500 });
+}
+
+async function readAll(stream: ReadableStream<Uint8Array> | null) {
+  if (!stream) return new Uint8Array(0);
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) chunks.push(value);
+  }
+  const total = chunks.reduce((acc, c) => acc + c.byteLength, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    out.set(c, offset);
+    offset += c.byteLength;
+  }
+  return out;
+}
+
 describe("GET /api/files/[fileId]", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -113,106 +237,76 @@ describe("GET /api/files/[fileId]", () => {
     expect(response.status).toBe(400);
     expect(response.headers.get("cache-control")).toBe("no-store");
     expect(response.headers.get("content-disposition")).toBeNull();
-    await expect(response.json()).resolves.toMatchObject({
-      status: 400,
-    });
+    await expect(response.json()).resolves.toMatchObject({ status: 400 });
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  test("calls upstream with Authorization, X-C4GH-Public-Key and forwards Range/If-Range", async () => {
+  test("probes /header with auth+public-key and /content with auth only", async () => {
     setSession(validSession);
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response("payload", {
-        status: 200,
-        headers: {
-          "content-type": "application/octet-stream",
-          "content-disposition": 'attachment; filename="upstream.c4gh"',
-        },
-      }),
-    );
-
-    const { request, params } = makeRequest("file-1", {
-      range: "bytes=0-1048575",
-      ifRange: '"etag-value"',
-    });
-    await GET(request, { params });
-
-    expect(fetchSpy).toHaveBeenCalledWith(`${sdaBaseUrl}/files/file-1`, {
-      headers: {
-        Authorization: "Bearer my-token",
-        "X-C4GH-Public-Key": "PUBKEY",
-        Range: "bytes=0-1048575",
-        "If-Range": '"etag-value"',
-      },
-      cache: "no-store",
-    });
-  });
-
-  test("forwards documented response headers and streams body on success", async () => {
-    setSession(validSession);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response("payload", {
-        status: 200,
-        headers: {
-          "content-type": "application/octet-stream",
-          "content-length": "7",
-          "content-disposition": 'attachment; filename="upstream.c4gh"',
-          "accept-ranges": "bytes",
-          etag: '"abc123"',
-          "last-modified": "Wed, 01 Jan 2025 00:00:00 GMT",
-        },
-      }),
-    );
+    const spy = installDispatchedFetch(defaultHandler);
 
     const { request, params } = makeRequest("file-1");
+    await GET(request, { params });
+
+    const calls = spy.mock.calls.map(([url, init]) => ({
+      url: String(url),
+      method: (init?.method || "GET").toUpperCase(),
+      headers: new Headers(init?.headers),
+    }));
+
+    const headerHead = calls.find(
+      (c) => c.url.endsWith("/header") && c.method === "HEAD",
+    );
+    const contentHead = calls.find(
+      (c) => c.url.endsWith("/content") && c.method === "HEAD",
+    );
+
+    expect(headerHead).toBeDefined();
+    expect(contentHead).toBeDefined();
+    expect(headerHead!.url).toBe(`${sdaBaseUrl}/files/file-1/header`);
+    expect(contentHead!.url).toBe(`${sdaBaseUrl}/files/file-1/content`);
+
+    expect(headerHead!.headers.get("authorization")).toBe("Bearer my-token");
+    expect(headerHead!.headers.get("x-c4gh-public-key")).toBe("PUBKEY");
+    expect(contentHead!.headers.get("authorization")).toBe("Bearer my-token");
+    expect(contentHead!.headers.get("x-c4gh-public-key")).toBeNull();
+  });
+
+  // Happy path: full file
+
+  test("returns 200 with stitched header+content and correct headers", async () => {
+    setSession(validSession);
+    installDispatchedFetch(defaultHandler);
+
+    const { request, params } = makeRequest("file-1", {
+      name: "samples/sample1.cram.c4gh",
+    });
     const response = await GET(request, { params });
 
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toBe(
       "application/octet-stream",
     );
-    expect(response.headers.get("content-length")).toBe("7");
-    expect(response.headers.get("content-disposition")).toBe(
-      'attachment; filename="upstream.c4gh"',
-    );
+    expect(response.headers.get("content-length")).toBe(String(TOTAL_LEN));
     expect(response.headers.get("accept-ranges")).toBe("bytes");
-    expect(response.headers.get("etag")).toBe('"abc123"');
-    expect(response.headers.get("last-modified")).toBe(
-      "Wed, 01 Jan 2025 00:00:00 GMT",
-    );
+    expect(response.headers.get("etag")).toBe(ETAG);
     expect(response.headers.get("cache-control")).toBe("no-store");
-    await expect(response.text()).resolves.toBe("payload");
-  });
-
-  test("fallback Content-Disposition uses basename from name query param", async () => {
-    setSession(validSession);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response("payload", {
-        status: 200,
-        headers: { "content-type": "application/octet-stream" },
-      }),
-    );
-
-    const { request, params } = makeRequest("file-1", {
-      name: "samples/controls/sample1.cram.c4gh",
-    });
-    const response = await GET(request, { params });
-
     expect(response.headers.get("content-disposition")).toBe(
       "attachment; " +
         'filename="sample1.cram.c4gh"; ' +
         "filename*=UTF-8''sample1.cram.c4gh",
     );
+    expect(response.headers.get("content-range")).toBeNull();
+
+    const body = await readAll(response.body);
+    expect(body.byteLength).toBe(TOTAL_LEN);
+    expect(body.subarray(0, HEADER_LEN)).toEqual(headerBody);
+    expect(body.subarray(HEADER_LEN)).toEqual(contentBody);
   });
 
-  test("fallback Content-Disposition uses <fileId>.c4gh when no name is given", async () => {
+  test("fallback Content-Disposition uses <fileId>.c4gh when no name given", async () => {
     setSession(validSession);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response("payload", {
-        status: 200,
-        headers: { "content-type": "application/octet-stream" },
-      }),
-    );
+    installDispatchedFetch(defaultHandler);
 
     const { request, params } = makeRequest("file-1");
     const response = await GET(request, { params });
@@ -224,47 +318,225 @@ describe("GET /api/files/[fileId]", () => {
     );
   });
 
+  // Resuming with range entirely inside the header
+
+  test("Range entirely inside the header → 206, no /content GET", async () => {
+    setSession(validSession);
+    const spy = installDispatchedFetch(defaultHandler);
+
+    const { request, params } = makeRequest("file-1", {
+      range: `bytes=10-${HEADER_LEN - 10}`,
+    });
+    const response = await GET(request, { params });
+
+    expect(response.status).toBe(206);
+    const expectedLen = HEADER_LEN - 10 - 10 + 1;
+    expect(response.headers.get("content-length")).toBe(String(expectedLen));
+    expect(response.headers.get("content-range")).toBe(
+      `bytes 10-${HEADER_LEN - 10}/${TOTAL_LEN}`,
+    );
+    expect(response.headers.get("etag")).toBe(ETAG);
+
+    const body = await readAll(response.body);
+    expect(body).toEqual(headerBody.subarray(10, HEADER_LEN - 10 + 1));
+
+    const getContent = spy.mock.calls.find(
+      ([url, init]) =>
+        String(url).endsWith("/content") &&
+        (init?.method || "GET").toUpperCase() === "GET",
+    );
+    expect(getContent).toBeUndefined();
+  });
+
+  // Resuming with range entirely inside the content
+
+  test("Range entirely inside the content → 206, no /header GET, translated Range", async () => {
+    setSession(validSession);
+    const spy = installDispatchedFetch(defaultHandler);
+
+    const start = HEADER_LEN + 100;
+    const end = HEADER_LEN + 199;
+
+    const { request, params } = makeRequest("file-1", {
+      range: `bytes=${start}-${end}`,
+    });
+    const response = await GET(request, { params });
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("content-length")).toBe("100");
+    expect(response.headers.get("content-range")).toBe(
+      `bytes ${start}-${end}/${TOTAL_LEN}`,
+    );
+
+    const body = await readAll(response.body);
+    expect(body).toEqual(contentBody.subarray(100, 200));
+
+    const getHeader = spy.mock.calls.find(
+      ([url, init]) =>
+        String(url).endsWith("/header") &&
+        (init?.method || "GET").toUpperCase() === "GET",
+    );
+    expect(getHeader).toBeUndefined();
+
+    const getContent = spy.mock.calls.find(
+      ([url, init]) =>
+        String(url).endsWith("/content") &&
+        (init?.method || "GET").toUpperCase() === "GET",
+    );
+    expect(getContent).toBeDefined();
+    const sentRange = new Headers(getContent![1]?.headers).get("range");
+    expect(sentRange).toBe("bytes=100-199");
+  });
+
+  // Resuming with range spanning both header and content
+
+  test("Range spanning header/content boundary → stitched 206", async () => {
+    setSession(validSession);
+    installDispatchedFetch(defaultHandler);
+
+    const start = HEADER_LEN - 10;
+    const end = HEADER_LEN + 9;
+
+    const { request, params } = makeRequest("file-1", {
+      range: `bytes=${start}-${end}`,
+    });
+    const response = await GET(request, { params });
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("content-length")).toBe("20");
+    expect(response.headers.get("content-range")).toBe(
+      `bytes ${start}-${end}/${TOTAL_LEN}`,
+    );
+
+    const body = await readAll(response.body);
+    const expected = new Uint8Array(20);
+    expected.set(headerBody.subarray(HEADER_LEN - 10), 0);
+    expected.set(contentBody.subarray(0, 10), 10);
+    expect(body).toEqual(expected);
+  });
+
+  // Resuming with open-ended range (partial file download with unknown total size)
+
+  test("open-ended Range bytes=N- → 206 from N to end", async () => {
+    setSession(validSession);
+    installDispatchedFetch(defaultHandler);
+
+    const start = HEADER_LEN + 500;
+
+    const { request, params } = makeRequest("file-1", {
+      range: `bytes=${start}-`,
+    });
+    const response = await GET(request, { params });
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("content-range")).toBe(
+      `bytes ${start}-${TOTAL_LEN - 1}/${TOTAL_LEN}`,
+    );
+
+    const body = await readAll(response.body);
+    expect(body).toEqual(contentBody.subarray(500));
+  });
+
+  // If-Range matching ETag should honor the Range, otherwise ignore it and return 200 with full body.
+
+  test("If-Range matching ETag honors the Range", async () => {
+    setSession(validSession);
+    installDispatchedFetch(defaultHandler);
+
+    const start = HEADER_LEN + 50;
+    const end = HEADER_LEN + 99;
+
+    const { request, params } = makeRequest("file-1", {
+      range: `bytes=${start}-${end}`,
+      ifRange: ETAG,
+    });
+    const response = await GET(request, { params });
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("content-range")).toBe(
+      `bytes ${start}-${end}/${TOTAL_LEN}`,
+    );
+  });
+
+  test("If-Range mismatching ETag → ignore Range, return 200 full body", async () => {
+    setSession(validSession);
+    installDispatchedFetch(defaultHandler);
+
+    const { request, params } = makeRequest("file-1", {
+      range: "bytes=0-99",
+      ifRange: '"stale-etag"',
+    });
+    const response = await GET(request, { params });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-length")).toBe(String(TOTAL_LEN));
+    expect(response.headers.get("content-range")).toBeNull();
+  });
+
+  // Unsatisfiable range
+
+  test("Range past end of file → 416 with Content-Range total", async () => {
+    setSession(validSession);
+    installDispatchedFetch(defaultHandler);
+
+    const { request, params } = makeRequest("file-1", {
+      range: `bytes=${TOTAL_LEN + 100}-`,
+    });
+    const response = await GET(request, { params });
+
+    expect(response.status).toBe(416);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("content-range")).toBe(`bytes */${TOTAL_LEN}`);
+    expect(response.headers.get("content-disposition")).toBeNull();
+    await expect(response.json()).resolves.toMatchObject({ status: 416 });
+  });
+
+  // Upstream errors during HEAD probes
+
   test.each([
     {
-      name: "401 from upstream surfaces detail from problem+json",
-      status: 401,
-      body: { title: "Unauthorized", status: 401, detail: "Token expired." },
-      expectedDetail: "Token expired.",
-    },
-    {
-      name: "403 from upstream surfaces detail from problem+json",
+      name: "404 on /header HEAD surfaces problem+json detail",
+      failed: "header",
       status: 403,
-      body: {
-        title: "Forbidden",
-        status: 403,
-        detail: "You do not have access.",
-      },
-      expectedDetail: "You do not have access.",
+      body: { title: "Forbidden", status: 403, detail: "No access." },
+      expectedDetail: "No access.",
     },
     {
-      name: "416 from upstream surfaces detail from problem+json",
-      status: 416,
-      body: {
-        title: "Range Not Satisfiable",
-        status: 416,
-        detail: "Out of range.",
-      },
-      expectedDetail: "Out of range.",
-    },
-    {
-      name: "500 from upstream surfaces detail from problem+json",
+      name: "500 on /content HEAD uses generic fallback",
+      failed: "content",
       status: 500,
-      body: { title: "Internal Server Error", status: 500, detail: "Boom." },
-      expectedDetail: "Boom.",
+      body: "boom",
+      expectedDetail: "Download failed with status 500.",
     },
-  ])("$name", async ({ status, body, expectedDetail }) => {
+  ])("$name", async ({ failed, status, body, expectedDetail }) => {
     setSession(validSession);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify(body), {
-        status,
-        headers: { "content-type": "application/problem+json" },
-      }),
-    );
+    installDispatchedFetch((url, init) => {
+      const method = (init?.method || "GET").toUpperCase();
+
+      if (failed === "header" && url.endsWith("/header") && method === "HEAD") {
+        const bodyStr = typeof body === "string" ? body : JSON.stringify(body);
+        const contentType =
+          typeof body === "string" ? "text/plain" : "application/problem+json";
+        return new Response(bodyStr, {
+          status,
+          headers: { "content-type": contentType },
+        });
+      }
+      if (
+        failed === "content" &&
+        url.endsWith("/content") &&
+        method === "HEAD"
+      ) {
+        const bodyStr = typeof body === "string" ? body : JSON.stringify(body);
+        const contentType =
+          typeof body === "string" ? "text/plain" : "application/problem+json";
+        return new Response(bodyStr, {
+          status,
+          headers: { "content-type": contentType },
+        });
+      }
+      return defaultHandler(url, init);
+    });
 
     const { request, params } = makeRequest("file-1");
     const response = await GET(request, { params });
@@ -278,54 +550,43 @@ describe("GET /api/files/[fileId]", () => {
     });
   });
 
-  test.each([
-    {
-      name: "401 with non-JSON body uses 401 fallback message",
-      status: 401,
-      body: "not json",
-      expected:
-        "Authentication with the download backend failed. Please sign in again.",
-    },
-    {
-      name: "403 with non-JSON body uses 403 fallback message",
-      status: 403,
-      body: "not json",
-      expected: "You do not have access to this file (or it does not exist).",
-    },
-    {
-      name: "416 with non-JSON body uses 416 fallback message",
-      status: 416,
-      body: "not json",
-      expected: "The requested byte range is not satisfiable.",
-    },
-    {
-      name: "500 with non-JSON body uses generic fallback message",
-      status: 500,
-      body: "not json",
-      expected: "Download failed with status 500.",
-    },
-  ])("$name", async ({ status, body, expected }) => {
+  // Upstream errors during body fetches
+
+  test("403 on /content GET after successful HEADs surfaces problem+json detail", async () => {
     setSession(validSession);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(body, {
-        status,
-        headers: { "content-type": "text/plain" },
-      }),
-    );
+    installDispatchedFetch((url, init) => {
+      const method = (init?.method || "GET").toUpperCase();
+      if (url.endsWith("/content") && method === "GET") {
+        return new Response(
+          JSON.stringify({
+            title: "Forbidden",
+            status: 403,
+            detail: "Access revoked mid-stream.",
+          }),
+          {
+            status: 403,
+            headers: { "content-type": "application/problem+json" },
+          },
+        );
+      }
+      return defaultHandler(url, init);
+    });
 
     const { request, params } = makeRequest("file-1");
     const response = await GET(request, { params });
 
-    expect(response.status).toBe(status);
+    expect(response.status).toBe(403);
     expect(response.headers.get("cache-control")).toBe("no-store");
     expect(response.headers.get("content-disposition")).toBeNull();
     await expect(response.json()).resolves.toEqual({
-      error: expected,
-      status,
+      error: "Access revoked mid-stream.",
+      status: 403,
     });
   });
 
-  test("returns 502 when fetch itself fails", async () => {
+  // Network failure
+
+  test("returns 502 when the probe fetch itself fails", async () => {
     setSession(validSession);
     vi.spyOn(globalThis, "fetch").mockRejectedValue(
       new Error("Network error"),

--- a/frontend/src/app/api/files/[fileId]/route.ts
+++ b/frontend/src/app/api/files/[fileId]/route.ts
@@ -181,16 +181,13 @@ export async function GET(
     );
   }
 
-  // Decide which upstream bodies we need. Note that no range is supported for the header by the backend API.
-  // The header is very small so it will be downloaded if needed and range will be adjusted.
-  // This is step 3 in supporting partial downloads.
-  const effective: Range = range || { start: 0, end: totalLen - 1 };
-  const needHeader = effective.start < headerLen;
-  const needContent = effective.end >= headerLen;
+  // If the requested range overlaps the header, ignore the range and thus serve the full file.
+  const effectiveRange = range && range.start >= headerLen ? range : null;
+  const isFullDownload = effectiveRange === null;
 
-  // Fetch (and buffer) just the slice of the header we need.
-  let headerSlice: Uint8Array | null = null;
-  if (needHeader) {
+  // Fetch the header only when we're serving a full download.
+  let headerBody: Uint8Array | null = null;
+  if (isFullDownload) {
     const r = await fetch(headerUrl, {
       headers: headerAuth,
       cache: "no-store",
@@ -198,34 +195,37 @@ export async function GET(
     if (!r.ok) {
       return translateUpstreamError(r, await extractProblemDetail(r));
     }
-    const buf = new Uint8Array(await r.arrayBuffer());
-    const sliceStart = effective.start;
-    const sliceEnd = Math.min(effective.end, headerLen - 1);
-    headerSlice = buf.subarray(sliceStart, sliceEnd + 1);
+    headerBody = new Uint8Array(await r.arrayBuffer());
   }
 
-  // Stream the content portion with a translated Range if it's a sub-slice.
-  let contentBody: ReadableStream<Uint8Array> | null = null;
-  if (needContent) {
-    const contentStart = Math.max(0, effective.start - headerLen);
-    const contentEnd = effective.end - headerLen;
-    const wantsSubSlice = contentStart > 0 || contentEnd < contentLen - 1;
-    const headers: Record<string, string> = { ...contentAuth };
-    if (wantsSubSlice) {
-      headers["Range"] = `bytes=${contentStart}-${contentEnd}`;
-    }
-    const r = await fetch(contentUrl, { headers, cache: "no-store" });
-    if (!r.ok) {
-      return translateUpstreamError(r, await extractProblemDetail(r));
-    }
-    contentBody = r.body;
-  }
+  // Stream the content portion, translating the Range into content-local
+  // offsets when present. This is step 3 in supporting partial downloads.
+  const contentStart = effectiveRange ? effectiveRange.start - headerLen : 0;
+  const contentEnd = effectiveRange
+    ? effectiveRange.end - headerLen
+    : contentLen - 1;
+  const wantsSubSlice = contentStart > 0 || contentEnd < contentLen - 1;
 
-  // Stitch header slice (if any) + content stream (if any).
-  // This is step 4 in supporting partial downloads.
+  const contentHeaders: Record<string, string> = { ...contentAuth };
+  if (wantsSubSlice) {
+    contentHeaders["Range"] = `bytes=${contentStart}-${contentEnd}`;
+  }
+  const contentResp = await fetch(contentUrl, {
+    headers: contentHeaders,
+    cache: "no-store",
+  });
+  if (!contentResp.ok) {
+    return translateUpstreamError(
+      contentResp,
+      await extractProblemDetail(contentResp),
+    );
+  }
+  const contentBody = contentResp.body;
+
+  // Stitch header bytes (full download only) + content stream.
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
-      if (headerSlice) controller.enqueue(headerSlice);
+      if (headerBody) controller.enqueue(headerBody);
       if (contentBody) {
         const reader = contentBody.getReader();
         try {
@@ -253,15 +253,16 @@ export async function GET(
     buildContentDisposition(getFallbackFilename(filePath, fileId)),
   );
 
-  const responseLen = effective.end - effective.start + 1;
-  responseHeaders.set("content-length", String(responseLen));
-
-  if (range) {
+  if (effectiveRange) {
+    const responseLen = effectiveRange.end - effectiveRange.start + 1;
+    responseHeaders.set("content-length", String(responseLen));
     responseHeaders.set(
       "content-range",
-      `bytes ${range.start}-${range.end}/${totalLen}`,
+      `bytes ${effectiveRange.start}-${effectiveRange.end}/${totalLen}`,
     );
     return new NextResponse(stream, { status: 206, headers: responseHeaders });
   }
+
+  responseHeaders.set("content-length", String(totalLen));
   return new NextResponse(stream, { status: 200, headers: responseHeaders });
 }

--- a/frontend/src/app/api/files/[fileId]/route.ts
+++ b/frontend/src/app/api/files/[fileId]/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/app/lib/session";
+import { getConfig } from "@/app/lib/config";
+
+// Response headers we want to forward from the backend to the browser so
+// that streaming, resuming, and the "save as" filename all work correctly.
+const FORWARDED_HEADERS = [
+  "content-type",
+  "content-length",
+  "content-disposition",
+  "content-range",
+  "accept-ranges",
+  "etag",
+  "last-modified",
+];
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ fileId: string }> },
+) {
+  const { fileId } = await params;
+  const sessionData = await getSession();
+
+  if (!sessionData?.token) {
+    return NextResponse.json({ error: "Not authenticated." }, { status: 401 });
+  }
+
+  if (!sessionData.publicKey?.key) {
+    return NextResponse.json(
+      {
+        error:
+          "No Crypt4GH public key configured. Upload your public key on the profile page before downloading files.",
+      },
+      { status: 400 },
+    );
+  }
+
+  const { sdaBaseUrl } = await getConfig();
+
+  const upstreamHeaders: Record<string, string> = {
+    Authorization: `Bearer ${sessionData.token}`,
+    "X-C4GH-Public-Key": sessionData.publicKey.key,
+  };
+
+  // Forward Range / If-Range so partial downloads and resume continue to work.
+  const range = request.headers.get("range");
+  if (range) upstreamHeaders["Range"] = range;
+  const ifRange = request.headers.get("if-range");
+  if (ifRange) upstreamHeaders["If-Range"] = ifRange;
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(
+      `${sdaBaseUrl}/files/${encodeURIComponent(fileId)}`,
+      {
+        headers: upstreamHeaders,
+        cache: "no-store",
+      },
+    );
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unknown error occurred";
+    return NextResponse.json(
+      { error: `Could not reach the download backend: ${message}` },
+      { status: 502 },
+    );
+  }
+
+  const responseHeaders = new Headers();
+  for (const name of FORWARDED_HEADERS) {
+    const value = upstream.headers.get(name);
+    if (value) responseHeaders.set(name, value);
+  }
+
+  // Make sure browsers actually trigger a file save even if the backend
+  // omits Content-Disposition for some reason.
+  if (!responseHeaders.has("content-disposition")) {
+    responseHeaders.set(
+      "content-disposition",
+      `attachment; filename="${fileId}.c4gh"`,
+    );
+  }
+
+  return new NextResponse(upstream.body, {
+    status: upstream.status,
+    headers: responseHeaders,
+  });
+}

--- a/frontend/src/app/api/files/[fileId]/route.ts
+++ b/frontend/src/app/api/files/[fileId]/route.ts
@@ -2,8 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/app/lib/session";
 import { getConfig } from "@/app/lib/config";
 
-// Response headers we want to forward from the backend to the browser so
-// that streaming, resuming, and the "save as" filename all work correctly.
+// Response headers we want to forward from upstream to the browser so
+// that streaming, resuming, and "save as" filename work correctly.
+// Only forwarded on successful (2xx) responses.
 const FORWARDED_HEADERS = [
   "content-type",
   "content-length",
@@ -14,6 +15,33 @@ const FORWARDED_HEADERS = [
   "last-modified",
 ];
 
+// Makes a JSON error responses predictable for the frontend to handle, with no caching.
+function errorResponse(status: number, message: string) {
+  return NextResponse.json(
+    { error: message, status },
+    {
+      status,
+      headers: { "cache-control": "no-store" },
+    },
+  );
+}
+
+// Extract a human-readable message from the upstream response. Expects an application/problem+json error body.
+async function extractProblemDetail(
+  upstream: Response,
+): Promise<string | null> {
+  const contentType = upstream.headers.get("content-type") || "";
+  if (!contentType.includes("json")) return null;
+  try {
+    const problem = await upstream.json();
+    if (typeof problem?.detail === "string") return problem.detail;
+    if (typeof problem?.title === "string") return problem.title;
+  } catch {
+    // Ignore malformed body and fall back to a generic message.
+  }
+  return null;
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ fileId: string }> },
@@ -22,16 +50,13 @@ export async function GET(
   const sessionData = await getSession();
 
   if (!sessionData?.token) {
-    return NextResponse.json({ error: "Not authenticated." }, { status: 401 });
+    return errorResponse(401, "Not authenticated.");
   }
 
   if (!sessionData.publicKey?.key) {
-    return NextResponse.json(
-      {
-        error:
-          "No Crypt4GH public key configured. Upload your public key on the profile page before downloading files.",
-      },
-      { status: 400 },
+    return errorResponse(
+      400,
+      "No Crypt4GH public key configured. Upload your public key on the profile page before downloading files.",
     );
   }
 
@@ -60,10 +85,25 @@ export async function GET(
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Unknown error occurred";
-    return NextResponse.json(
-      { error: `Could not reach the download backend: ${message}` },
-      { status: 502 },
+    return errorResponse(
+      502,
+      `Could not reach the download backend: ${message}`,
     );
+  }
+
+  // Return upstream errors as clean JSON error response with appropriate status code.
+  // Don't attempt to stream the body in this case.
+  if (!upstream.ok) {
+    const detail = await extractProblemDetail(upstream);
+    const fallback =
+      upstream.status === 401
+        ? "Authentication with the download backend failed. Please sign in again."
+        : upstream.status === 403
+          ? "You do not have access to this file (or it does not exist)."
+          : upstream.status === 416
+            ? "The requested byte range is not satisfiable."
+            : `Download failed with status ${upstream.status}.`;
+    return errorResponse(upstream.status, detail || fallback);
   }
 
   const responseHeaders = new Headers();
@@ -80,6 +120,8 @@ export async function GET(
       `attachment; filename="${fileId}.c4gh"`,
     );
   }
+
+  responseHeaders.set("cache-control", "no-store");
 
   return new NextResponse(upstream.body, {
     status: upstream.status,

--- a/frontend/src/app/api/files/[fileId]/route.ts
+++ b/frontend/src/app/api/files/[fileId]/route.ts
@@ -2,20 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/app/lib/session";
 import { getConfig } from "@/app/lib/config";
 
-// Response headers we want to forward from upstream to the browser so
-// that streaming, resuming, and "save as" filename work correctly.
-// Only forwarded on successful (2xx) responses.
-const FORWARDED_HEADERS = [
-  "content-type",
-  "content-length",
-  "content-disposition",
-  "content-range",
-  "accept-ranges",
-  "etag",
-  "last-modified",
-];
-
-// Makes a JSON error responses predictable for the frontend to handle, with no caching.
+// Predictable JSON error response for the frontend, with no caching.
 function errorResponse(status: number, message: string) {
   return NextResponse.json(
     { error: message, status },
@@ -26,7 +13,7 @@ function errorResponse(status: number, message: string) {
   );
 }
 
-// Extract a human-readable message from the upstream response. Expects an application/problem+json error body.
+// Extract a human-readable message from an application/problem+json body.
 async function extractProblemDetail(
   upstream: Response,
 ): Promise<string | null> {
@@ -42,8 +29,23 @@ async function extractProblemDetail(
   return null;
 }
 
+function translateUpstreamError(
+  upstream: Response,
+  detail: string | null,
+): NextResponse {
+  const fallback =
+    upstream.status === 401
+      ? "Authentication with the download backend failed. Please sign in again."
+      : upstream.status === 403
+        ? "You do not have access to this file (or it does not exist)."
+        : upstream.status === 416
+          ? "The requested byte range is not satisfiable."
+          : `Download failed with status ${upstream.status}.`;
+  return errorResponse(upstream.status, detail || fallback);
+}
+
 function buildContentDisposition(filename: string): string {
-  // filePath is assumed to be HTTP-header-safe
+  // filename is assumed to be HTTP-header-safe
   const encoded = encodeURIComponent(filename);
   return `attachment; filename="${filename}"; filename*=UTF-8''${encoded}`;
 }
@@ -54,6 +56,23 @@ function getFallbackFilename(filePath: string | null, fileId: string): string {
     if (basename) return basename;
   }
   return `${fileId}.c4gh`; //2nd fallback
+}
+
+type Range = { start: number; end: number };
+
+// Parse a single-range "bytes=<start>-<end?>" header in combined-stream space.
+// Returns null if not present/unparseable or "unsatisfiable" if start >= totalLen or start > end.
+function parseRange(header: string | null, totalLen: number): Range | "unsatisfiable" | null {
+  if (!header) return null;
+
+  const m = header.match(/^bytes=(\d+)-(\d*)$/);
+  if (!m) return null;
+
+  const start = parseInt(m[1], 10);
+  const end = m[2] ? parseInt(m[2], 10) : totalLen - 1;
+  if (start >= totalLen || start > end) return "unsatisfiable";
+
+  return { start, end: Math.min(end, totalLen - 1) };
 }
 
 export async function GET(
@@ -76,27 +95,34 @@ export async function GET(
   }
 
   const { sdaBaseUrl } = await getConfig();
-
-  const upstreamHeaders: Record<string, string> = {
+  const headerAuth = {
     Authorization: `Bearer ${sessionData.token}`,
     "X-C4GH-Public-Key": sessionData.publicKey.key,
   };
+  const contentAuth = {
+    Authorization: `Bearer ${sessionData.token}`,
+  };
+  const headerUrl = `${sdaBaseUrl}/files/${encodeURIComponent(fileId)}/header`;
+  const contentUrl = `${sdaBaseUrl}/files/${encodeURIComponent(fileId)}/content`;
 
-  // Forward Range / If-Range so partial downloads and resume continue to work.
-  const range = request.headers.get("range");
-  if (range) upstreamHeaders["Range"] = range;
-  const ifRange = request.headers.get("if-range");
-  if (ifRange) upstreamHeaders["If-Range"] = ifRange;
-
-  let upstream: Response;
+  // Probe both sub-resources in parallel to learn sizes and the stable content ETag.
+  // This is the first step in order to support partial downloads. We rely on headless file (content)
+  // ranges(and etag) because the header part is unstable due to re-encryption.
+  let headerHead: Response;
+  let contentHead: Response;
   try {
-    upstream = await fetch(
-      `${sdaBaseUrl}/files/${encodeURIComponent(fileId)}`,
-      {
-        headers: upstreamHeaders,
+    [headerHead, contentHead] = await Promise.all([
+      fetch(headerUrl, {
+        method: "HEAD",
+        headers: headerAuth,
         cache: "no-store",
-      },
-    );
+      }),
+      fetch(contentUrl, {
+        method: "HEAD",
+        headers: contentAuth,
+        cache: "no-store",
+      }),
+    ]);
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Unknown error occurred";
@@ -105,41 +131,135 @@ export async function GET(
       `Could not reach the download backend: ${message}`,
     );
   }
-
-  // Return upstream errors as clean JSON error response with appropriate status code.
-  // Don't attempt to stream the body in this case.
-  if (!upstream.ok) {
-    const detail = await extractProblemDetail(upstream);
-    const fallback =
-      upstream.status === 401
-        ? "Authentication with the download backend failed. Please sign in again."
-        : upstream.status === 403
-          ? "You do not have access to this file (or it does not exist)."
-          : upstream.status === 416
-            ? "The requested byte range is not satisfiable."
-            : `Download failed with status ${upstream.status}.`;
-    return errorResponse(upstream.status, detail || fallback);
+  if (!headerHead.ok) {
+    return translateUpstreamError(
+      headerHead,
+      await extractProblemDetail(headerHead),
+    );
   }
-
-  const responseHeaders = new Headers();
-  for (const name of FORWARDED_HEADERS) {
-    const value = upstream.headers.get(name);
-    if (value) responseHeaders.set(name, value);
-  }
-
-  // Make sure browsers actually trigger a file save even if the backend
-  // omits Content-Disposition for some reason.
-  if (!responseHeaders.has("content-disposition")) {
-    responseHeaders.set(
-      "content-disposition",
-      buildContentDisposition(getFallbackFilename(filePath, fileId)),
+  if (!contentHead.ok) {
+    return translateUpstreamError(
+      contentHead,
+      await extractProblemDetail(contentHead),
     );
   }
 
-  responseHeaders.set("cache-control", "no-store");
+  const headerLen = parseInt(
+    headerHead.headers.get("content-length") || "0",
+    10,
+  );
+  const contentLen = parseInt(
+    contentHead.headers.get("content-length") || "0",
+    10,
+  );
+  const totalLen = headerLen + contentLen;
+  const etag = contentHead.headers.get("etag");
 
-  return new NextResponse(upstream.body, {
-    status: upstream.status,
-    headers: responseHeaders,
+  // Use If-Range only when it matches the (stable, content-derived) ETag.
+  // This is step 2 in supporting partial downloads.
+  const ifRange = request.headers.get("if-range");
+  const honorRange = !ifRange || (etag !== null && ifRange === etag);
+  const rangeHeader = honorRange ? request.headers.get("range") : null;
+  const range = parseRange(rangeHeader, totalLen);
+
+  if (range === "unsatisfiable") {
+    return NextResponse.json(
+      {
+        error: "The requested byte range is not satisfiable.",
+        status: 416,
+      },
+      {
+        status: 416,
+        headers: {
+          "cache-control": "no-store",
+          "content-range": `bytes */${totalLen}`,
+        },
+      },
+    );
+  }
+
+  // Decide which upstream bodies we need. Note that no range is supported for the header by the backend API.
+  // The header is very small so it will be downloaded if needed and range will be adjusted.
+  // This is step 3 in supporting partial downloads.
+  const effective: Range = range || { start: 0, end: totalLen - 1 };
+  const needHeader = effective.start < headerLen;
+  const needContent = effective.end >= headerLen;
+
+  // Fetch (and buffer) just the slice of the header we need.
+  let headerSlice: Uint8Array | null = null;
+  if (needHeader) {
+    const r = await fetch(headerUrl, {
+      headers: headerAuth,
+      cache: "no-store",
+    });
+    if (!r.ok) {
+      return translateUpstreamError(r, await extractProblemDetail(r));
+    }
+    const buf = new Uint8Array(await r.arrayBuffer());
+    const sliceStart = effective.start;
+    const sliceEnd = Math.min(effective.end, headerLen - 1);
+    headerSlice = buf.subarray(sliceStart, sliceEnd + 1);
+  }
+
+  // Stream the content portion with a translated Range if it's a sub-slice.
+  let contentBody: ReadableStream<Uint8Array> | null = null;
+  if (needContent) {
+    const contentStart = Math.max(0, effective.start - headerLen);
+    const contentEnd = effective.end - headerLen;
+    const wantsSubSlice =
+      contentStart > 0 || contentEnd < contentLen - 1;
+    const headers: Record<string, string> = { ...contentAuth };
+    if (wantsSubSlice) {
+      headers["Range"] = `bytes=${contentStart}-${contentEnd}`;
+    }
+    const r = await fetch(contentUrl, { headers, cache: "no-store" });
+    if (!r.ok) {
+      return translateUpstreamError(r, await extractProblemDetail(r));
+    }
+    contentBody = r.body;
+  }
+
+  // Stitch header slice (if any) + content stream (if any).
+  // This is step 4 in supporting partial downloads.
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      if (headerSlice) controller.enqueue(headerSlice);
+      if (contentBody) {
+        const reader = contentBody.getReader();
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            if (value) controller.enqueue(value);
+          }
+        } catch (e) {
+          controller.error(e);
+          return;
+        }
+      }
+      controller.close();
+    },
   });
+
+  const responseHeaders = new Headers();
+  responseHeaders.set("content-type", "application/octet-stream");
+  responseHeaders.set("accept-ranges", "bytes");
+  responseHeaders.set("cache-control", "no-store");
+  if (etag) responseHeaders.set("etag", etag);
+  responseHeaders.set(
+    "content-disposition",
+    buildContentDisposition(getFallbackFilename(filePath, fileId)),
+  );
+
+  const responseLen = effective.end - effective.start + 1;
+  responseHeaders.set("content-length", String(responseLen));
+
+  if (range) {
+    responseHeaders.set(
+      "content-range",
+      `bytes ${range.start}-${range.end}/${totalLen}`,
+    );
+    return new NextResponse(stream, { status: 206, headers: responseHeaders });
+  }
+  return new NextResponse(stream, { status: 200, headers: responseHeaders });
 }

--- a/frontend/src/app/api/files/[fileId]/route.ts
+++ b/frontend/src/app/api/files/[fileId]/route.ts
@@ -42,12 +42,27 @@ async function extractProblemDetail(
   return null;
 }
 
+function buildContentDisposition(filename: string): string {
+  // filePath is assumed to be HTTP-header-safe
+  const encoded = encodeURIComponent(filename);
+  return `attachment; filename="${filename}"; filename*=UTF-8''${encoded}`;
+}
+
+function getFallbackFilename(filePath: string | null, fileId: string): string {
+  if (filePath) {
+    const basename = filePath.split("/").pop();
+    if (basename) return basename;
+  }
+  return `${fileId}.c4gh`; //2nd fallback
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ fileId: string }> },
 ) {
   const { fileId } = await params;
   const sessionData = await getSession();
+  const filePath = request.nextUrl.searchParams.get("name");
 
   if (!sessionData?.token) {
     return errorResponse(401, "Not authenticated.");
@@ -117,7 +132,7 @@ export async function GET(
   if (!responseHeaders.has("content-disposition")) {
     responseHeaders.set(
       "content-disposition",
-      `attachment; filename="${fileId}.c4gh"`,
+      buildContentDisposition(getFallbackFilename(filePath, fileId)),
     );
   }
 

--- a/frontend/src/app/api/files/[fileId]/route.ts
+++ b/frontend/src/app/api/files/[fileId]/route.ts
@@ -156,7 +156,12 @@ export async function GET(
     10,
   );
   const totalLen = headerLen + contentLen;
-  const etag = contentHead.headers.get("etag");
+  // Bind the ETag to the recipient public key so that resumes only succeed when the same
+  // key is in use.
+  const contentEtagRaw = contentHead.headers.get("etag");
+  const etag = contentEtagRaw
+    ? `"${contentEtagRaw.replace(/^"|"$/g, "")}-${sessionData.publicKey.pemChecksum}"`
+    : null;
 
   // Use If-Range only when it matches the (stable, content-derived) ETag.
   // This is step 2 in supporting partial downloads.

--- a/frontend/src/app/api/files/[fileId]/route.ts
+++ b/frontend/src/app/api/files/[fileId]/route.ts
@@ -62,7 +62,10 @@ type Range = { start: number; end: number };
 
 // Parse a single-range "bytes=<start>-<end?>" header in combined-stream space.
 // Returns null if not present/unparseable or "unsatisfiable" if start >= totalLen or start > end.
-function parseRange(header: string | null, totalLen: number): Range | "unsatisfiable" | null {
+function parseRange(
+  header: string | null,
+  totalLen: number,
+): Range | "unsatisfiable" | null {
   if (!header) return null;
 
   const m = header.match(/^bytes=(\d+)-(\d*)$/);
@@ -206,8 +209,7 @@ export async function GET(
   if (needContent) {
     const contentStart = Math.max(0, effective.start - headerLen);
     const contentEnd = effective.end - headerLen;
-    const wantsSubSlice =
-      contentStart > 0 || contentEnd < contentLen - 1;
+    const wantsSubSlice = contentStart > 0 || contentEnd < contentLen - 1;
     const headers: Record<string, string> = { ...contentAuth };
     if (wantsSubSlice) {
       headers["Range"] = `bytes=${contentStart}-${contentEnd}`;

--- a/frontend/src/app/components/DatasetFiles.tsx
+++ b/frontend/src/app/components/DatasetFiles.tsx
@@ -34,7 +34,7 @@ export default function DatasetFiles({
 
     downloadUrl: canDownload ? (
       <a
-        href={`/api/files/${encodeURIComponent(file.fileId)}`}
+        href={`/api/files/${encodeURIComponent(file.fileId)}?name=${encodeURIComponent(file.filePath)}`}
         download
         target="_blank"
         rel="noopener noreferrer"

--- a/frontend/src/app/components/DatasetFiles.tsx
+++ b/frontend/src/app/components/DatasetFiles.tsx
@@ -36,7 +36,8 @@ export default function DatasetFiles({
       <a
         href={`/api/files/${encodeURIComponent(file.fileId)}`}
         download
-        rel="noopener"
+        target="_blank"
+        rel="noopener noreferrer"
       >
         Download file
       </a>

--- a/frontend/src/app/components/DatasetFiles.tsx
+++ b/frontend/src/app/components/DatasetFiles.tsx
@@ -11,11 +11,13 @@ import { ItemSelector, useItemsPerPage } from "./ItemsPerPage";
 type DatasetFilesProps = {
   files: DatasetFile[];
   defaultItemsPerPage: number;
+  canDownload?: boolean;
 };
 
 export default function DatasetFiles({
   files,
   defaultItemsPerPage = 15,
+  canDownload = true,
 }: DatasetFilesProps) {
   const { itemsPerPage, setItemsPerPage, itemsPerPageOptions } =
     useItemsPerPage(defaultItemsPerPage);
@@ -30,7 +32,22 @@ export default function DatasetFiles({
       <ClipboardValue key={c.checksum} value={c.checksum} label={c.type} />
     )),
 
-    downloadUrl: <a href={file.downloadUrl}>Download file</a>,
+    downloadUrl: canDownload ? (
+      <a
+        href={`/api/files/${encodeURIComponent(file.fileId)}`}
+        download
+        rel="noopener"
+      >
+        Download file
+      </a>
+    ) : (
+      <span
+        className="text-muted"
+        title="Upload your Crypt4GH public key on the profile page to enable downloads."
+      >
+        Download file
+      </span>
+    ),
   }));
 
   const filteredFiles = useMemo(() => {


### PR DESCRIPTION
## Related issue(s) and PR(s)

This PR closes #14.

Implements single-file download as a Next.js server-side proxy in front of the SDA Data Out API. Files are streamed from the upstream backend through `/api/files/[fileId]` so that the bearer token and Crypt4GH public key never reach the browser. Supports the full Crypt4GH download lifecycle: full downloads, partial downloads, and **resume** via HTTP Range / If-Range.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## List of changes made

### Per-file download action
- "Download file" link added to each row in the dataset files table.
- Disabled with an explanatory tooltip when the user hasn't uploaded a Crypt4GH public key yet, plus a page-level warning alert linking to the profile page.
- Link opens in a new tab so any error response doesn't replace the dataset view.

### Streaming proxy route (`app/api/files/[fileId]`)
- Forwards the request to the SDA backend with the user's bearer token (from the encrypted session cookie) and `X-C4GH-Public-Key` header.
- Streams the response body to the browser without buffering.
- Returns a properly formed `Content-Disposition` header with a meaningful filename derived from the file's `filePath`
- `Cache-Control: no-store` on every response.

### Resume / partial download support
The combined `/files/{fileId}` endpoint has an unstable ETag (per the spec: re-encrypted header bytes vary per request), which breaks Firefox's `If-Range`-based resume. To get a stable ETag and robust resume, the proxy talks to the split endpoints:

1. Parallel `HEAD` to `/files/{fileId}/header` and `/files/{fileId}/content` to learn sizes and capture the **stable content ETag**.
2. Parse incoming `Range`; ignore `Range` if `If-Range` doesn't match our ETag (per RFC 9110).
3. Fetch only the upstream bytes needed:
   - Range entirely inside the content → fetch `/content` with a translated Range.
   - Range overlapping with header  → do not resume. restart full file download instead. This avoids stitching partial header A with partial header B, since header is not guaranteed to be stable. Here we assume stable header length but not header bytes.
4. Synthesize our own `Content-Length`, `Content-Range`, `ETag`, `Accept-Ranges`, returning 200 for full downloads and 206 for partial ones.

To the browser this all looks like a single combined Crypt4GH stream `[re-encrypted header | encrypted content]`.

The proxy `ETAG` is constructed by the content `ETAG` and the c4gh pub key `md5 checksum`, This avoids situations where a user ries to resume a file download with an uploaded c4gh pub key that is different than the one originally used in the partial file.

### Graceful error handling
Upstream `application/problem+json` responses (401/403/416/5xx) are unpacked and re-emitted as a predictable JSON shape `{ error, status }` with no `Content-Disposition`. This prevents the browser from offering JSON error payloads as `.c4gh` downloads. Status-specific fallback messages cover non-JSON upstream bodies. Network failures surface as 502.


## Testing

- The new route is covered by unittests.
- Added the option to include a large file in a seeded dataset of the sda dev environment so that the resuming of file downloads can be tested manually.

### Manual testing
- Bring up the sda dev stack and seed a 2GB file to dataset `EGAD00000000002` by running:
```bash
docker compose -f sda-dev-stack.yml --profile seed-large-file up
```
- Run the webapp compose as usual. Check that the Download file button in the files view of a dataset is disabled if no c4gh pub key is uploaded.
- Upload  a c4gh pub key and download a file.
- Go to the above mentioned dataset and try to download the 2GB file. Pause the download and then resume it. See that resuming works. 

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] All Acceptance Criteria (AC) Fulfilled and checked in the Related issue

- [x] **Documentation Updated (if applicable):**
  - Relevant documentation is current.