### PR TITLE
fix: format dataset size with filesize

### DIFF
--- a/frontend/src/app/components/DatasetDetails.tsx
+++ b/frontend/src/app/components/DatasetDetails.tsx
@@ -1,4 +1,5 @@
 import { DatasetMetadata } from "../actions/datasets";
+import { filesize } from "filesize";
 
 type DatasetDetailsProps = {
   dataset: DatasetMetadata;
@@ -21,7 +22,7 @@ export default function DatasetDetails({
                   {dataset.files} {dataset.files === 1 ? "file" : "files"}
                 </p>
               </div>
-              <p className="fs-5">{dataset.size} bytes</p>
+              <p className="fs-5">{filesize(dataset.size)}</p>
             </div>
             <span
               className="d-inline-flex align-self-start mb-3 px-2 py-1 text-secondary-emphasis


### PR DESCRIPTION
## Related issue(s) and PR(s)

This PR closes #89 

<!-- Include below a description of the bug and the proposed fix -->

## Bug description

Dataset total size was displayed as raw bytes, which is hard to read.

## Fix implemented

Use the `filesize` library to format `dataset.size` in `DatasetDetails.tsx`.

## Screenshot
<img width="766" height="359" alt="image" src="https://github.com/user-attachments/assets/bc5efcd7-704e-4ed0-8d99-e91f8673cbbc" />

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
- [x] The fix has been verified manually, if applicable
