### PR TITLE
Add more optional mock data

### DIFF
--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -182,6 +182,16 @@ docker compose -f sda-dev-stack.yml --profile seed-large-file up -d
 
 This will include a 2 GB file in dataset `EGAD00000000002`.
 
+### Optional: seed large dataset
+
+Sometimes it may be useful to include a large dataset for testing e.g. pagination. To achive this include the `seed-large-dataset` profile in the docker compose command. For example:
+
+```bash
+docker compose -f sda-dev-stack.yml --profile seed-large-file --profile seed-large-dataset up -d
+```
+
+This will include a 40k file dataset `EGAD00000040000`.
+
 ## Cleanup
 
 ``` bash

--- a/dev-tools/sda-dev-stack.yml
+++ b/dev-tools/sda-dev-stack.yml
@@ -193,6 +193,28 @@ services:
       - ./seed-large-file.sh:/seed-large-file.sh:ro
       - shared:/shared
 
+  seed-large-dataset:
+    extends:
+      service: seed
+    profiles: ["seed-large-dataset"]
+    depends_on:
+      seed:
+        condition: service_completed_successfully
+    command:
+      - /bin/sh
+      - -c
+      - |
+        apt-get -o DPkg::Lock::Timeout=60 update > /dev/null
+        apt-get -o DPkg::Lock::Timeout=60 install -y curl postgresql-client > /dev/null
+        pip install --upgrade pip > /dev/null
+        pip install crypt4gh > /dev/null
+        curl -sL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc
+        chmod +x /usr/local/bin/mc
+        sh /seed-large-dataset.sh
+    volumes:
+      - ./seed-large-dataset.sh:/seed-large-dataset.sh:ro
+      - shared:/shared
+
   # Mock OIDC server with /tokens endpoint for easy token retrieval
   mockauth:
     command:

--- a/dev-tools/seed-large-dataset.sh
+++ b/dev-tools/seed-large-dataset.sh
@@ -1,0 +1,105 @@
+#!/bin/sh
+# Seed a single large dataset with 40,000 file entries for webapp load testing.
+# DB-only: does NOT upload any new objects to MinIO.
+# All file rows reuse the existing base archive object's header/checksums/sizes,
+# so the entries are referentially consistent but share storage.
+# Idempotent: safe to re-run.
+set -e
+
+SEED_MARKER="/shared/.download_v2_large_dataset_seeded"
+SEED_MARKER_TMP="/shared/.download_v2_large_dataset_seeded.tmp"
+
+if [ -f "$SEED_MARKER" ]; then
+  echo "Large dataset already seeded, skipping."
+  exit 0
+fi
+
+# Requires the base seed to have run (we reuse its metadata + archive object)
+if [ ! -f /tmp/seed_metadata.env ]; then
+  echo "ERROR: /tmp/seed_metadata.env not found. Run the base seed script first." >&2
+  exit 1
+fi
+
+. /tmp/seed_metadata.env
+
+echo "=== Seeding large dataset (40k files) ==="
+
+SUBMISSION_USER="integration_test@example.org"
+LARGE_DATASET_STABLE_ID="EGAD00000040000"
+LARGE_DATASET_TITLE="Large Test Dataset (40k files)"
+FILE_COUNT=40000
+
+# Offset the file sequence so we don't collide with the base seed's UUIDs/stable IDs.
+# Base seed uses sequence 1..(101 + sum(1..10)*12 = ~1265). 100000+ is safely clear.
+FILE_SEQ_OFFSET=100000
+
+pg_isready -h postgres -p 5432 -U postgres
+
+psql -h postgres -U postgres -d sda -v ON_ERROR_STOP=1 << EOSQL
+BEGIN;
+
+-- Create the dataset
+INSERT INTO sda.datasets (stable_id, title)
+  VALUES ('$LARGE_DATASET_STABLE_ID', '$LARGE_DATASET_TITLE')
+  ON CONFLICT (stable_id) DO NOTHING;
+
+-- Bulk-create 40k file rows in one shot using generate_series.
+-- UUID format: aaaaaaaa-bbbb-cccc-dddd-XXXXXXXXXXXX (12 hex digits = decimal sequence)
+-- Stable ID:   EGAF<11-digit zero-padded sequence>
+-- File path:   generated-file-<11-digit sequence>.c4gh
+WITH seq AS (
+  SELECT generate_series($FILE_SEQ_OFFSET, $FILE_SEQ_OFFSET + $FILE_COUNT - 1) AS n
+)
+INSERT INTO sda.files (
+  id, stable_id, submission_user, submission_file_path,
+  archive_file_path, archive_location, archive_file_size, decrypted_file_size,
+  header, encryption_method
+)
+SELECT
+  ('aaaaaaaa-bbbb-cccc-dddd-' || lpad(n::text, 12, '0'))::uuid,
+  'EGAF' || lpad(n::text, 11, '0'),
+  '$SUBMISSION_USER',
+  'generated-file-' || lpad(n::text, 11, '0') || '.c4gh',
+  'test-file.c4gh',                 -- reuse existing archive object
+  'http://s3:9000/archive',
+  $ARCHIVE_SIZE,
+  $DECRYPTED_SIZE,
+  '$HEADER_HEX',
+  'CRYPT4GH'
+FROM seq
+ON CONFLICT (id) DO NOTHING;
+
+-- Link all newly created files to the large dataset
+INSERT INTO sda.file_dataset (file_id, dataset_id)
+SELECT
+  ('aaaaaaaa-bbbb-cccc-dddd-' || lpad(n::text, 12, '0'))::uuid,
+  d.id
+FROM generate_series($FILE_SEQ_OFFSET, $FILE_SEQ_OFFSET + $FILE_COUNT - 1) AS n
+CROSS JOIN sda.datasets d
+WHERE d.stable_id = '$LARGE_DATASET_STABLE_ID'
+ON CONFLICT DO NOTHING;
+
+-- Bulk-insert checksums (ARCHIVED + UNENCRYPTED per file)
+INSERT INTO sda.checksums (file_id, checksum, type, source)
+SELECT
+  ('aaaaaaaa-bbbb-cccc-dddd-' || lpad(n::text, 12, '0'))::uuid,
+  '$ARCHIVE_CHECKSUM',
+  'SHA256',
+  'ARCHIVED'
+FROM generate_series($FILE_SEQ_OFFSET, $FILE_SEQ_OFFSET + $FILE_COUNT - 1) AS n;
+
+INSERT INTO sda.checksums (file_id, checksum, type, source)
+SELECT
+  ('aaaaaaaa-bbbb-cccc-dddd-' || lpad(n::text, 12, '0'))::uuid,
+  '$DECRYPTED_CHECKSUM',
+  'SHA256',
+  'UNENCRYPTED'
+FROM generate_series($FILE_SEQ_OFFSET, $FILE_SEQ_OFFSET + $FILE_COUNT - 1) AS n;
+
+COMMIT;
+EOSQL
+
+echo "Seeded $FILE_COUNT files into dataset $LARGE_DATASET_STABLE_ID"
+touch "$SEED_MARKER_TMP"
+mv "$SEED_MARKER_TMP" "$SEED_MARKER"
+echo "=== Large dataset seed complete ==="

--- a/dev-tools/seed-large-dataset.sh
+++ b/dev-tools/seed-large-dataset.sh
@@ -15,12 +15,12 @@ if [ -f "$SEED_MARKER" ]; then
 fi
 
 # Requires the base seed to have run (we reuse its metadata + archive object)
-if [ ! -f /tmp/seed_metadata.env ]; then
-  echo "ERROR: /tmp/seed_metadata.env not found. Run the base seed script first." >&2
+if [ ! -f /shared/seed_metadata.env ]; then
+  echo "ERROR: /shared/seed_metadata.env not found. Run the base seed script first." >&2
   exit 1
 fi
 
-. /tmp/seed_metadata.env
+. /shared/seed_metadata.env
 
 echo "=== Seeding large dataset (40k files) ==="
 

--- a/dev-tools/seed.sh
+++ b/dev-tools/seed.sh
@@ -62,6 +62,8 @@ with open("/tmp/seed_metadata.env", "w") as f:
     f.write(f"DECRYPTED_SIZE={len(plaintext)}\n")
     f.write(f"ARCHIVE_CHECKSUM={hashlib.sha256(body).hexdigest()}\n")
     f.write(f"DECRYPTED_CHECKSUM={hashlib.sha256(plaintext).hexdigest()}\n")
+    f.write(f"ARCHIVE_MD5_CHECKSUM={hashlib.md5(body).hexdigest()}\n")
+    f.write(f"DECRYPTED_MD5_CHECKSUM={hashlib.md5(plaintext).hexdigest()}\n")
 
 print(f"Header: {len(header)} bytes, Body: {len(body)} bytes")
 PYEOF
@@ -103,6 +105,9 @@ done
 dataset_idx=2
 while [ "$dataset_idx" -le 120 ]; do
   file_count=$(( ((dataset_idx - 2) % 10) + 1 ))
+  if [ "$dataset_idx" -eq 2 ]; then
+    file_count=2
+  fi
   j=1
   while [ "$j" -le "$file_count" ]; do
     OBJ_NAME=$(printf "generated-file-%011d.c4gh" "$GLOBAL_FILE_SEQ")
@@ -157,7 +162,9 @@ INSERT INTO sda.file_dataset (file_id, dataset_id)
 DELETE FROM sda.checksums WHERE file_id = '$BASE_FILE_UUID';
 INSERT INTO sda.checksums (file_id, checksum, type, source) VALUES
   ('$BASE_FILE_UUID', '$ARCHIVE_CHECKSUM', 'SHA256', 'ARCHIVED'),
-  ('$BASE_FILE_UUID', '$DECRYPTED_CHECKSUM', 'SHA256', 'UNENCRYPTED');
+  ('$BASE_FILE_UUID', '$DECRYPTED_CHECKSUM', 'SHA256', 'UNENCRYPTED'),
+  ('$BASE_FILE_UUID', '$ARCHIVE_MD5_CHECKSUM', 'MD5', 'ARCHIVED'),
+  ('$BASE_FILE_UUID', '$DECRYPTED_MD5_CHECKSUM', 'MD5', 'UNENCRYPTED');
 EOSQL
 
 # File sequence counter:
@@ -204,7 +211,9 @@ INSERT INTO sda.file_dataset (file_id, dataset_id)
 DELETE FROM sda.checksums WHERE file_id = '$FILE_UUID';
 INSERT INTO sda.checksums (file_id, checksum, type, source) VALUES
   ('$FILE_UUID', '$ARCHIVE_CHECKSUM', 'SHA256', 'ARCHIVED'),
-  ('$FILE_UUID', '$DECRYPTED_CHECKSUM', 'SHA256', 'UNENCRYPTED');
+  ('$FILE_UUID', '$DECRYPTED_CHECKSUM', 'SHA256', 'UNENCRYPTED'),
+  ('$FILE_UUID', '$ARCHIVE_MD5_CHECKSUM', 'MD5', 'ARCHIVED'),
+  ('$FILE_UUID', '$DECRYPTED_MD5_CHECKSUM', 'MD5', 'UNENCRYPTED');
 EOSQL
 
   NEXT_FILE_SEQ=$((NEXT_FILE_SEQ+1))
@@ -220,6 +229,9 @@ while [ "$dataset_idx" -le 120 ]; do
   DATASET_STABLE_ID=$(printf "EGAD%011d" "$dataset_idx")
   DATASET_TITLE=$(printf "Test Dataset %03d" "$dataset_idx")
   FILE_COUNT=$(( ((dataset_idx - 2) % 10) + 1 ))
+  if [ "$dataset_idx" -eq 2 ]; then
+    FILE_COUNT=2
+  fi
 
   psql -h postgres -U postgres -d sda << EOSQL
 INSERT INTO sda.datasets (stable_id, title)
@@ -264,9 +276,19 @@ INSERT INTO sda.file_dataset (file_id, dataset_id)
   ON CONFLICT DO NOTHING;
 
 DELETE FROM sda.checksums WHERE file_id = '$FILE_UUID';
-INSERT INTO sda.checksums (file_id, checksum, type, source) VALUES
-  ('$FILE_UUID', '$ARCHIVE_CHECKSUM', 'SHA256', 'ARCHIVED'),
-  ('$FILE_UUID', '$DECRYPTED_CHECKSUM', 'SHA256', 'UNENCRYPTED');
+
+INSERT INTO sda.checksums (file_id, checksum, type, source)
+  SELECT '$FILE_UUID', '$ARCHIVE_CHECKSUM', 'SHA256', 'ARCHIVED'
+  WHERE NOT (($dataset_idx = 2 AND $j = 1) OR $dataset_idx = 3);
+INSERT INTO sda.checksums (file_id, checksum, type, source)
+  SELECT '$FILE_UUID', '$DECRYPTED_CHECKSUM', 'SHA256', 'UNENCRYPTED'
+  WHERE NOT (($dataset_idx = 2 AND $j = 1) OR $dataset_idx = 3);
+INSERT INTO sda.checksums (file_id, checksum, type, source)
+  SELECT '$FILE_UUID', '$ARCHIVE_MD5_CHECKSUM', 'MD5', 'ARCHIVED'
+  WHERE (($dataset_idx = 2 AND $j = 1) OR $dataset_idx = 3);
+INSERT INTO sda.checksums (file_id, checksum, type, source)
+  SELECT '$FILE_UUID', '$DECRYPTED_MD5_CHECKSUM', 'MD5', 'UNENCRYPTED'
+  WHERE (($dataset_idx = 2 AND $j = 1) OR $dataset_idx = 3);
 EOSQL
 
     NEXT_FILE_SEQ=$((NEXT_FILE_SEQ+1))

--- a/dev-tools/seed.sh
+++ b/dev-tools/seed.sh
@@ -56,7 +56,7 @@ with open("/tmp/body.bin", "wb") as f:
 
 plaintext = open("/tmp/plaintext.bin", "rb").read()
 
-with open("/tmp/seed_metadata.env", "w") as f:
+with open("/shared/seed_metadata.env", "w") as f:
     f.write(f"HEADER_HEX={header.hex()}\n")
     f.write(f"ARCHIVE_SIZE={len(body)}\n")
     f.write(f"DECRYPTED_SIZE={len(plaintext)}\n")
@@ -69,7 +69,7 @@ print(f"Header: {len(header)} bytes, Body: {len(body)} bytes")
 PYEOF
 
 # Load computed metadata
-. /tmp/seed_metadata.env
+. /shared/seed_metadata.env
 
 # MinIO setup
 mc alias set myminio http://s3:9000 access secretKey --quiet


### PR DESCRIPTION
This PR add more mock data to cover more cases:

- a new seed-large-dataset profile is added to the sda dev compose file. This will seed a 40k file dataset.
- `seed.sh` has been modified so that there is a dataset with both sha256 and md5 checksums and another one with mixed checksums so as to test the batch download checksum feature.