### PR TITLE
production build fails

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -27,3 +27,7 @@ jobs:
         if: always()
         working-directory: frontend
         run: npm run format
+
+      - name: "Make sure that the frontend builds"
+        working-directory: frontend
+        run: npm run build

--- a/frontend/src/app/components/Pagination.tsx
+++ b/frontend/src/app/components/Pagination.tsx
@@ -80,7 +80,6 @@ export default function Pagination({
                 className="page-link"
                 onClick={() => onPageChange(1)}
                 disabled={isFirstPage}
-                autoComplete="off"
               >
                 <span className="d-inline d-sm-none">&lt;&lt;</span>
                 <span className="d-none d-sm-inline">First</span>
@@ -93,7 +92,6 @@ export default function Pagination({
                 className="page-link"
                 onClick={() => onPageChange(currentPage - 1)}
                 disabled={isFirstPage}
-                autoComplete="off"
               >
                 <span className="d-inline d-sm-none">&lt;</span>
                 <span className="d-none d-sm-inline">Previous</span>
@@ -132,7 +130,6 @@ export default function Pagination({
                 className="page-link"
                 onClick={() => onPageChange(currentPage + 1)}
                 disabled={isLastPage}
-                autoComplete="off"
               >
                 <span className="d-inline d-sm-none">&gt;</span>
                 <span className="d-none d-sm-inline">Next</span>
@@ -147,7 +144,6 @@ export default function Pagination({
                 className="page-link"
                 onClick={() => onPageChange(totalPages)}
                 disabled={isLastPage}
-                autoComplete="off"
               >
                 <span className="d-inline d-sm-none">&gt;&gt;</span>
                 <span className="d-none d-sm-inline ">Last</span>


### PR DESCRIPTION
## Related issue(s) and PR(s)

This PR closes #78 and #98

- The one issue is that production build fails due to typing error (autocomplete in button)
- A GitHub action fix making sure that the production will build

## Bug description

A type error: " Property 'autoComplete' does not exist on type 'DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>'." 

## Fix implemented

- The element autocomplete off was removed for button in Pagination. Since it was introduced because of a Firefox state issue (see [comment](https://github.com/NBISweden/sda-download-ui/pull/90#issuecomment-4533137912) ) I also made sure to check the pagination in the Firefox browser and it works as expected.
- The GitHub action linting has a step called "_Make sure that the frontend builds_" and this tries `npm run build`. If that gives errors then the production compose will not build.

## Testing

- Before checking out this branch try in develop `npm run build` or ` ./compose-prod.sh up --build`
- Proceed to this branch and again try `npm run build` or ` ./compose-prod.sh up --build`
- Make sure the GitHub linting action is successful


## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
- [x] Relevant tests have been added or updated
- [x] The fix has been verified manually, if applicable
