### PR TITLE
fix: defer InfoTooltip rendering until hydration to avoid SSR mismatch

### DIFF
--- a/frontend/src/app/components/InfoTooltip.tsx
+++ b/frontend/src/app/components/InfoTooltip.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import * as Tooltip from "@radix-ui/react-tooltip";
-import { type ReactNode } from "react";
+import { type ReactNode, useSyncExternalStore } from "react";
+
+const emptySubscribe = () => () => {};
 
 type InfoTooltipProps = {
   content: ReactNode;
@@ -14,6 +16,14 @@ export default function InfoTooltip({
   children,
   monospace = false,
 }: InfoTooltipProps) {
+  const hydrated = useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false,
+  );
+
+  if (!hydrated) return <>{children}</>;
+
   return (
     <Tooltip.Provider delayDuration={200}>
       <Tooltip.Root>


### PR DESCRIPTION
## Related issue(s) and PR(s)

This PR relates to #88 and #96, which introduced the bug.

<!-- Include below a description of the bug and the proposed fix -->

## Bug description

Hovering a dataset size threw a React hydration error. Radix Tooltip's
`asChild` composition renders server markup that doesn't match the client,
so the server-side rendered trigger and the hydrated trigger diverged.

## Fix implemented

`InfoTooltip` now renders the bare child during SSR and only mounts the
Radix tooltip after hydration (via a `useSyncExternalStore` hydration check),
so server and client markup match.

## Testing

- Before: open a dataset page → hydration error in the console.
- After: same page → no error; tooltips still appear on hover/focus.

## Further comments

Used `useSyncExternalStore` (with a server snapshot) instead of a
`useState` + `useEffect` mount flag, since React 19 warns against calling
`setState` synchronously in an effect. Same behavior, no warning.

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
- [x] The fix has been verified manually, if applicable
