### PR TITLE
Add tooltip for long filepaths

### DIFF
--- a/frontend/src/app/components/ClipboardValue.tsx
+++ b/frontend/src/app/components/ClipboardValue.tsx
@@ -6,11 +6,13 @@ export function ClipboardValue({
   icon,
   copiedIcon,
   label,
+  truncate = false,
 }: {
   value: string;
   icon?: string;
   copiedIcon?: string;
   label?: string;
+  truncate?: boolean;
 }) {
   const [isCopied, setIsCopied] = useState(false);
   const copyToClipboard = useCallback(async () => {
@@ -20,21 +22,30 @@ export function ClipboardValue({
   copiedIcon = copiedIcon || "clipboard-check";
   icon = icon || "clipboard";
   const currentIcon = isCopied ? copiedIcon : icon;
+  const copyAriaLabel = `Copy ${label ?? "value"} to clipboard`;
   return (
     <span className="mx-1">
-      {label && (
-        <InfoTooltip content={value} monospace>
-          <em tabIndex={0}>{label}</em>
-        </InfoTooltip>
-      )}
+      {label &&
+        (truncate ? (
+          <InfoTooltip content={value} monospace>
+            <span className="clipboard-value-truncate" tabIndex={0}>
+              {label}
+            </span>
+          </InfoTooltip>
+        ) : (
+          <InfoTooltip content={value} monospace>
+            <em tabIndex={0}>{label}</em>
+          </InfoTooltip>
+        ))}
       <InfoTooltip content={isCopied ? "Copied!" : "Copy"}>
         <span
           onClick={copyToClipboard}
           className="ps-1"
           role="button"
           tabIndex={0}
+          aria-label={copyAriaLabel}
         >
-          <i className={`bi bi-${currentIcon}`}></i>
+          <i className={`bi bi-${currentIcon}`} aria-hidden="true"></i>
         </span>
       </InfoTooltip>
     </span>

--- a/frontend/src/app/components/ClipboardValue.tsx
+++ b/frontend/src/app/components/ClipboardValue.tsx
@@ -1,42 +1,33 @@
-import { useCallback, useState } from "react";
+import { useCallback, useState, type ReactNode } from "react";
 import InfoTooltip from "./InfoTooltip";
 
 export function ClipboardValue({
   value,
   icon,
   copiedIcon,
-  label,
-  truncate = false,
+  ariaLabel,
+  children,
 }: {
   value: string;
   icon?: string;
   copiedIcon?: string;
-  label?: string;
-  truncate?: boolean;
+  ariaLabel?: string;
+  children?: ReactNode;
 }) {
   const [isCopied, setIsCopied] = useState(false);
   const copyToClipboard = useCallback(async () => {
     await navigator.clipboard.writeText(value);
     setIsCopied(true);
   }, [value]);
-  copiedIcon = copiedIcon || "clipboard-check";
-  icon = icon || "clipboard";
-  const currentIcon = isCopied ? copiedIcon : icon;
-  const copyAriaLabel = `Copy ${label ?? "value"} to clipboard`;
+
+  const currentIcon = isCopied
+    ? (copiedIcon ?? "clipboard-check")
+    : (icon ?? "clipboard");
+  const copyAriaLabel = ariaLabel ?? "Copy value to clipboard";
+
   return (
     <span className="mx-1">
-      {label &&
-        (truncate ? (
-          <InfoTooltip content={value} monospace>
-            <span className="clipboard-value-truncate" tabIndex={0}>
-              {label}
-            </span>
-          </InfoTooltip>
-        ) : (
-          <InfoTooltip content={value} monospace>
-            <em tabIndex={0}>{label}</em>
-          </InfoTooltip>
-        ))}
+      {children}
       <InfoTooltip content={isCopied ? "Copied!" : "Copy"}>
         <span
           onClick={copyToClipboard}

--- a/frontend/src/app/components/DatasetFiles.tsx
+++ b/frontend/src/app/components/DatasetFiles.tsx
@@ -6,6 +6,7 @@ import Pagination from "./Pagination";
 import { Table } from "./Table";
 import { filesize } from "filesize";
 import { ClipboardValue } from "./ClipboardValue";
+import InfoTooltip from "./InfoTooltip";
 import { ItemSelector, useItemsPerPage } from "./ItemsPerPage";
 import { ChecksumExportActions } from "./ChecksumExportActions";
 
@@ -34,11 +35,28 @@ export default function DatasetFiles({
     fileId: file.fileId,
     rawFilePath: file.filePath,
     filePath: (
-      <ClipboardValue value={file.filePath} label={file.filePath} truncate />
+      <ClipboardValue
+        value={file.filePath}
+        ariaLabel={`Copy ${file.filePath} to clipboard`}
+      >
+        <InfoTooltip content={file.filePath} monospace>
+          <span className="clipboard-value-truncate" tabIndex={0}>
+            {file.filePath}
+          </span>
+        </InfoTooltip>
+      </ClipboardValue>
     ),
     decryptedSize: filesize(file.decryptedSize),
     checksums: file.checksums.map((c) => (
-      <ClipboardValue key={c.checksum} value={c.checksum} label={c.type} />
+      <ClipboardValue
+        key={c.checksum}
+        value={c.checksum}
+        ariaLabel={`Copy ${c.type} to clipboard`}
+      >
+        <InfoTooltip content={c.checksum} monospace>
+          <em tabIndex={0}>{c.type}</em>
+        </InfoTooltip>
+      </ClipboardValue>
     )),
 
     downloadUrl: canDownload ? (

--- a/frontend/src/app/components/DatasetFiles.tsx
+++ b/frontend/src/app/components/DatasetFiles.tsx
@@ -32,7 +32,10 @@ export default function DatasetFiles({
 
   const formattedFiles = files.map((file) => ({
     fileId: file.fileId,
-    filePath: file.filePath,
+    rawFilePath: file.filePath,
+    filePath: (
+      <ClipboardValue value={file.filePath} label={file.filePath} truncate />
+    ),
     decryptedSize: filesize(file.decryptedSize),
     checksums: file.checksums.map((c) => (
       <ClipboardValue key={c.checksum} value={c.checksum} label={c.type} />
@@ -67,7 +70,7 @@ export default function DatasetFiles({
     return formattedFiles.filter((file) => {
       const searchableMetadata = [
         file.fileId,
-        file.filePath,
+        file.rawFilePath,
         file.decryptedSize,
         file.checksums,
       ]
@@ -189,6 +192,13 @@ export default function DatasetFiles({
       {currentFiles.length > 0 && (
         <Table
           data={currentFiles}
+          columns={[
+            "fileId",
+            "filePath",
+            "decryptedSize",
+            "checksums",
+            "downloadUrl",
+          ]}
           getRowId={(file) => file.fileId}
           selectedIds={selectedFileIds}
           onToggleRow={toggleFileSelection}

--- a/frontend/src/app/globals.scss
+++ b/frontend/src/app/globals.scss
@@ -142,3 +142,13 @@ body {
 .info-tooltip-arrow {
   fill: $violet;
 }
+
+.clipboard-value-truncate {
+  display: inline-block;
+  max-width: 18ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: bottom;
+  cursor: help;
+}


### PR DESCRIPTION
<!-- Remove sections from this template that are not used -->

## Related issue(s) and PR(s)

This PR closes #77

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change

<!-- Please delete options that are not relevant -->

- [x] New feature (non-breaking change which adds functionality)

## List of changes made

- truncate long filepaths in the table with an ellipsis at the end
- Reuse existing components to:
  - include a button for copying whole file path
  - show whole file path on hover

## Screenshot of the fix

<!-- Attach screenshot if relevant -->

## Testing

<!-- Please delete options that are not relevant -->

- go to a dataset details page
- see the shortened file paths in the table
- try the tooltip on hover
- try the copy-button

## Further comments

<!-- Specify questions or related information -->

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any
- [ ] All Acceptance Criteria (AC) Fulfilled and checked in the Related issue

- [ ] **Documentation Updated (if applicable):**
  - Relevant documentation is current.
  - Considerations: in-code comments, generated documentation, README files, Swagger docs, Postman collections, Confluence pages, etc.
- [ ] **Follow-up Backlog Items Created (if applicable):**
  - Necessary follow-up tasks have been identified and added to the backlog.
  - Considerations: next iteration tasks, performance enhancements, visual improvements, refactoring needs, addressing technical debt.
