### PR TITLE
feat: add loading skeletons for datasets pages

### DIFF
--- a/frontend/src/app/(pages)/datasets/[datasetId]/loading.tsx
+++ b/frontend/src/app/(pages)/datasets/[datasetId]/loading.tsx
@@ -1,0 +1,96 @@
+export default function Loading() {
+  const placeholderRows = Array.from({ length: 8 });
+  // Column widths approximate the real DatasetFiles table so the layout does
+  // not jump when data arrives; `fill` keeps placeholder bars looking like
+  // varied content rather than uniform full-width blocks.
+  const fileColumns = [
+    { header: "Select", width: "7%", fill: "col-5" },
+    { header: "File ID", width: "16%", fill: "col-9" },
+    { header: "Path", width: "29%", fill: "col-11" },
+    { header: "Decrypted size", width: "15%", fill: "col-5" },
+    { header: "Checksums", width: "21%", fill: "col-8" },
+    { header: " ", width: "12%", fill: "col-7" },
+  ];
+
+  return (
+    <main aria-busy="true" aria-label="Loading dataset">
+      <div className="container">
+        <div className="row mt-5 placeholder-glow">
+          {/* Dataset details card placeholder */}
+          <div className="card px-0 col-12 col-lg-6">
+            <div className="card-header">
+              <h3 className="card-title m-3 col-6">
+                <span className="placeholder col-12"></span>
+              </h3>
+            </div>
+            <div className="card-body mx-3 mb-2">
+              <div className="d-flex">
+                <div className="d-flex flex-column flex-grow-1 align-items-start mb-4 mb-sm-0">
+                  <p className="fs-1 mb-1 col-4">
+                    <span className="placeholder col-12"></span>
+                  </p>
+                  <span className="fs-5 col-3">
+                    <span className="placeholder col-12"></span>
+                  </span>
+                </div>
+                <span className="placeholder col-3 align-self-start rounded-1"></span>
+              </div>
+              <div className="d-flex justify-content-start mt-3">
+                <span
+                  className="btn btn-primary disabled placeholder col-3 me-3"
+                  aria-hidden="true"
+                ></span>
+                <span
+                  className="btn btn-primary disabled placeholder col-3"
+                  aria-hidden="true"
+                ></span>
+              </div>
+            </div>
+          </div>
+
+          {/* Files section placeholder */}
+          <div className="container mt-5 px-0 placeholder-glow">
+            <h3>Files</h3>
+
+            {/* Filter input placeholder */}
+            <div className="input-group col-12 my-3">
+              <span className="input-group-text">Filter files</span>
+              <span className="form-control placeholder col-6"></span>
+            </div>
+
+            {/* Files table placeholder */}
+            <div className="table-container">
+              <table className="table" style={{ tableLayout: "fixed" }}>
+                <colgroup>
+                  {fileColumns.map((column, index) => (
+                    <col key={index} style={{ width: column.width }} />
+                  ))}
+                </colgroup>
+                <thead>
+                  <tr>
+                    {fileColumns.map((column, index) => (
+                      <th key={index} scope="col">
+                        {column.header}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {placeholderRows.map((_, rowIndex) => (
+                    <tr key={rowIndex}>
+                      {fileColumns.map((column, colIndex) => (
+                        <td key={colIndex}>
+                          <span className={`placeholder ${column.fill}`}></span>
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/(pages)/datasets/loading.tsx
+++ b/frontend/src/app/(pages)/datasets/loading.tsx
@@ -1,0 +1,44 @@
+export default function Loading() {
+  const placeholderCards = Array.from({ length: 6 });
+
+  return (
+    <main aria-busy="true" aria-label="Loading datasets">
+      <div className="container">
+        <h2 className="my-3">Datasets</h2>
+        <div className="row placeholder-glow">
+          {/* Filter input placeholder */}
+          <div className="input-group col-12 mb-3">
+            <span className="input-group-text">Filter datasets</span>
+            <span className="form-control placeholder col-6"></span>
+          </div>
+
+          {/* Dataset card placeholders */}
+          {placeholderCards.map((_, index) => (
+            <div className="col col-lg-4 p-2" key={index}>
+              <div className="card shadow-sm">
+                <div className="card-body d-flex flex-column">
+                  <div className="d-flex justify-content-between">
+                    <h3 className="card-title h5 col-5">
+                      <span className="placeholder col-12"></span>
+                    </h3>
+                    <span className="placeholder col-2 rounded-1"></span>
+                  </div>
+                  <div className="d-flex flex-wrap justify-content-between mb-3">
+                    <span className="placeholder col-5"></span>
+                    <span className="placeholder col-3"></span>
+                  </div>
+                  <div className="text-left">
+                    <span
+                      className="btn btn-secondary disabled placeholder col-5"
+                      aria-hidden="true"
+                    ></span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/components/DatasetsList.tsx
+++ b/frontend/src/app/components/DatasetsList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import Link from "next/link";
 import Pagination from "@/app/components/Pagination";
 import type { DatasetMetadata } from "../actions/datasets";
 import Alert from "@/app/components/Alert";
@@ -134,12 +135,12 @@ export default function DatasetsList({
                   </InfoTooltip>
                 </div>
                 <div className="text-left">
-                  <a
+                  <Link
                     className="btn btn-secondary"
                     href={`/datasets/${dataset.datasetId}`}
                   >
                     View dataset
-                  </a>
+                  </Link>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
<!-- Remove sections from this template that are not used -->

## Related issue(s) and PR(s)

This PR closes #93.

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change

<!-- Please delete options that are not relevant -->

- [x] New feature (non-breaking change which adds functionality)

## List of changes made

<!-- Specify what changes have been made and why -->
- Added route-level `loading.tsx` skeletons for the datasets list (/datasets) and dataset detail (`/datasets/[datasetId]`) pages, mirroring each layout to avoid layout shift while data loads.
- Switched the dataset card's "View dataset" link from `<a>` to `next/link`, so navigation is client-side and the skeleton actually shows during loading instead of after a full-page reload.

## Screenshot of the fix

<!-- Attach screenshot if relevant -->
`/datasets/loading.tsx`
<img width="1328" height="431" alt="image" src="https://github.com/user-attachments/assets/37a44802-9983-4b54-9b81-5ceecf0d5f91" />

`/datasets/[datasetId]/loading.tsx`
<img width="1362" height="922" alt="image" src="https://github.com/user-attachments/assets/8eadd6ff-a693-4de3-9d77-e80f51c065a1" />

## Testing

<!-- Please delete options that are not relevant -->

1. Go to `/datasets` — the list skeleton shows while datasets load.
2. Click View dataset — the detail skeleton shows while files load.

## Further comments

Implemented loading skeletons rather than a generic spinner component named in the AC, for better UX in my opinion. The skeletons omit conditional/width-shifting elements to avoid misrepresenting the layout. But if you disagree, I can replace this with a spinner solution instead.

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] All Acceptance Criteria (AC) Fulfilled and checked in the Related issue (see spinner --> skeleton note above)

