### PR TITLE
Allow download of all checksums for a dataset

### DIFF
--- a/frontend/src/app/(pages)/datasets/[datasetId]/page.tsx
+++ b/frontend/src/app/(pages)/datasets/[datasetId]/page.tsx
@@ -77,7 +77,7 @@ export default async function DatasetDetailsView({
             />
           ) : (
             <>
-              <DatasetDetails dataset={dataset} />
+              <DatasetDetails dataset={dataset} files={files} />
               <div className="container mt-5 px-0">
                 <h3>Files</h3>
                 {!hasPublicKey && (

--- a/frontend/src/app/components/DatasetDetails.tsx
+++ b/frontend/src/app/components/DatasetDetails.tsx
@@ -1,13 +1,16 @@
-import { DatasetMetadata } from "../actions/datasets";
+import { DatasetMetadata, DatasetFile } from "../actions/datasets";
 import { filesize } from "filesize";
 import InfoTooltip from "./InfoTooltip";
+import DownloadChecksumsButton from "./DownloadChecksumsButton";
 
 type DatasetDetailsProps = {
   dataset: DatasetMetadata;
+  files: DatasetFile[];
 };
 
 export default function DatasetDetails({
   dataset: dataset,
+  files: files,
 }: DatasetDetailsProps) {
   return (
     <>
@@ -43,9 +46,10 @@ export default function DatasetDetails({
             <button className="btn btn-primary align-self-start me-3">
               Download dataset
             </button>
-            <button className="btn btn-primary align-self-start">
-              Download checksums
-            </button>
+            <DownloadChecksumsButton
+              files={files}
+              datasetId={dataset.datasetId}
+            />
           </div>
         </div>
       </div>

--- a/frontend/src/app/components/DownloadChecksumsButton.test.ts
+++ b/frontend/src/app/components/DownloadChecksumsButton.test.ts
@@ -1,11 +1,6 @@
 import { describe, it, expect } from "vitest";
-import {
-  pickChecksumType,
-  buildChecksumFileContent,
-} from "./DownloadChecksumsButton";
+import { pickChecksumType } from "./DownloadChecksumsButton";
 import type { DatasetFile } from "../actions/datasets";
-
-// --- Test helpers ---------------------------------------------------------
 
 const makeFile = (
   overrides: Partial<DatasetFile> & { checksums: DatasetFile["checksums"] },
@@ -18,10 +13,8 @@ const makeFile = (
   ...overrides,
 });
 
-// --- pickChecksumType ----------------------------------------------------
-
 describe("pickChecksumType", () => {
-  it("returns 'sha256' when both sha256 and md5 are present", () => {
+  it("prefers sha256 when every file has both sha256 and md5", () => {
     const files = [
       makeFile({
         checksums: [
@@ -33,119 +26,26 @@ describe("pickChecksumType", () => {
     expect(pickChecksumType(files)).toBe("sha256");
   });
 
-  it("returns 'sha256' when only sha256 is present", () => {
+  it("falls back to md5 when sha256 is missing from some file", () => {
     const files = [
-      makeFile({ checksums: [{ type: "sha256", checksum: "abc" }] }),
+      makeFile({
+        checksums: [
+          { type: "sha256", checksum: "abc" },
+          { type: "md5", checksum: "111" },
+        ],
+      }),
+      makeFile({
+        checksums: [{ type: "md5", checksum: "222" }],
+      }),
     ];
-    expect(pickChecksumType(files)).toBe("sha256");
-  });
-
-  it("returns 'md5' when only md5 is present", () => {
-    const files = [makeFile({ checksums: [{ type: "md5", checksum: "111" }] })];
     expect(pickChecksumType(files)).toBe("md5");
   });
 
-  it("prefers sha256 even when sha256 and md5 are split across files", () => {
+  it("returns null when neither sha256 nor md5 covers all files", () => {
     const files = [
-      makeFile({ checksums: [{ type: "md5", checksum: "111" }] }),
       makeFile({ checksums: [{ type: "sha256", checksum: "abc" }] }),
-    ];
-    expect(pickChecksumType(files)).toBe("sha256");
-  });
-
-  it("returns null when no supported checksum types are present", () => {
-    const files = [
-      makeFile({
-        checksums: [{ type: "crc32" as "sha256", checksum: "xyz" }],
-      }),
+      makeFile({ checksums: [{ type: "md5", checksum: "111" }] }),
     ];
     expect(pickChecksumType(files)).toBeNull();
-  });
-
-  it("returns null when files have no checksums", () => {
-    const files = [makeFile({ checksums: [] })];
-    expect(pickChecksumType(files)).toBeNull();
-  });
-
-  it("returns null for an empty files array", () => {
-    expect(pickChecksumType([])).toBeNull();
-  });
-});
-
-// --- buildChecksumFileContent --------------------------------------------
-
-describe("buildChecksumFileContent", () => {
-  it("formats lines as '<checksum>  <filepath>' with a trailing newline", () => {
-    const files = [
-      makeFile({
-        filePath: "samples/file1.cram.c4gh",
-        checksums: [{ type: "sha256", checksum: "abc123" }],
-      }),
-      makeFile({
-        filePath: "samples/file2.cram.c4gh",
-        checksums: [{ type: "sha256", checksum: "def456" }],
-      }),
-    ];
-
-    expect(buildChecksumFileContent(files, "sha256")).toBe(
-      "abc123  samples/file1.cram.c4gh\n" + "def456  samples/file2.cram.c4gh\n",
-    );
-  });
-
-  it("uses exactly two spaces between checksum and filepath", () => {
-    const files = [
-      makeFile({
-        filePath: "a.c4gh",
-        checksums: [{ type: "sha256", checksum: "abc" }],
-      }),
-    ];
-
-    expect(buildChecksumFileContent(files, "sha256")).toBe("abc  a.c4gh\n");
-  });
-
-  it("includes only checksums of the requested type", () => {
-    const files = [
-      makeFile({
-        filePath: "file1.c4gh",
-        checksums: [
-          { type: "sha256", checksum: "sha-1" },
-          { type: "md5", checksum: "md5-1" },
-        ],
-      }),
-    ];
-
-    const result = buildChecksumFileContent(files, "sha256");
-    expect(result).toBe("sha-1  file1.c4gh\n");
-    expect(result).not.toContain("md5-1");
-  });
-
-  it("skips files that don't have the requested checksum type", () => {
-    const files = [
-      makeFile({
-        filePath: "file1.c4gh",
-        checksums: [{ type: "sha256", checksum: "sha-1" }],
-      }),
-      makeFile({
-        filePath: "file2.c4gh",
-        checksums: [{ type: "md5", checksum: "md5-2" }],
-      }),
-    ];
-
-    expect(buildChecksumFileContent(files, "sha256")).toBe(
-      "sha-1  file1.c4gh\n",
-    );
-  });
-
-  it("ends with exactly one trailing newline", () => {
-    const files = [
-      makeFile({
-        filePath: "file1.c4gh",
-        checksums: [{ type: "sha256", checksum: "abc" }],
-      }),
-    ];
-
-    const result = buildChecksumFileContent(files, "sha256");
-    expect(result.endsWith("\n")).toBe(true);
-    expect(result.endsWith("\n\n")).toBe(false);
   });
 });

--- a/frontend/src/app/components/DownloadChecksumsButton.test.ts
+++ b/frontend/src/app/components/DownloadChecksumsButton.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest";
+import {
+  pickChecksumType,
+  buildChecksumFileContent,
+} from "./DownloadChecksumsButton";
+import type { DatasetFile } from "../actions/datasets";
+
+// --- Test helpers ---------------------------------------------------------
+
+const makeFile = (
+  overrides: Partial<DatasetFile> & { checksums: DatasetFile["checksums"] },
+): DatasetFile => ({
+  fileId: "file-id",
+  filePath: "path/to/file.c4gh",
+  size: 100,
+  decryptedSize: 90,
+  downloadUrl: "/files/file-id",
+  ...overrides,
+});
+
+// --- pickChecksumType ----------------------------------------------------
+
+describe("pickChecksumType", () => {
+  it("returns 'sha256' when both sha256 and md5 are present", () => {
+    const files = [
+      makeFile({
+        checksums: [
+          { type: "sha256", checksum: "abc" },
+          { type: "md5", checksum: "111" },
+        ],
+      }),
+    ];
+    expect(pickChecksumType(files)).toBe("sha256");
+  });
+
+  it("returns 'sha256' when only sha256 is present", () => {
+    const files = [
+      makeFile({ checksums: [{ type: "sha256", checksum: "abc" }] }),
+    ];
+    expect(pickChecksumType(files)).toBe("sha256");
+  });
+
+  it("returns 'md5' when only md5 is present", () => {
+    const files = [makeFile({ checksums: [{ type: "md5", checksum: "111" }] })];
+    expect(pickChecksumType(files)).toBe("md5");
+  });
+
+  it("prefers sha256 even when sha256 and md5 are split across files", () => {
+    const files = [
+      makeFile({ checksums: [{ type: "md5", checksum: "111" }] }),
+      makeFile({ checksums: [{ type: "sha256", checksum: "abc" }] }),
+    ];
+    expect(pickChecksumType(files)).toBe("sha256");
+  });
+
+  it("returns null when no supported checksum types are present", () => {
+    const files = [
+      makeFile({
+        checksums: [{ type: "crc32" as "sha256", checksum: "xyz" }],
+      }),
+    ];
+    expect(pickChecksumType(files)).toBeNull();
+  });
+
+  it("returns null when files have no checksums", () => {
+    const files = [makeFile({ checksums: [] })];
+    expect(pickChecksumType(files)).toBeNull();
+  });
+
+  it("returns null for an empty files array", () => {
+    expect(pickChecksumType([])).toBeNull();
+  });
+});
+
+// --- buildChecksumFileContent --------------------------------------------
+
+describe("buildChecksumFileContent", () => {
+  it("formats lines as '<checksum>  <filepath>' with a trailing newline", () => {
+    const files = [
+      makeFile({
+        filePath: "samples/file1.cram.c4gh",
+        checksums: [{ type: "sha256", checksum: "abc123" }],
+      }),
+      makeFile({
+        filePath: "samples/file2.cram.c4gh",
+        checksums: [{ type: "sha256", checksum: "def456" }],
+      }),
+    ];
+
+    expect(buildChecksumFileContent(files, "sha256")).toBe(
+      "abc123  samples/file1.cram.c4gh\n" + "def456  samples/file2.cram.c4gh\n",
+    );
+  });
+
+  it("uses exactly two spaces between checksum and filepath", () => {
+    const files = [
+      makeFile({
+        filePath: "a.c4gh",
+        checksums: [{ type: "sha256", checksum: "abc" }],
+      }),
+    ];
+
+    expect(buildChecksumFileContent(files, "sha256")).toBe("abc  a.c4gh\n");
+  });
+
+  it("includes only checksums of the requested type", () => {
+    const files = [
+      makeFile({
+        filePath: "file1.c4gh",
+        checksums: [
+          { type: "sha256", checksum: "sha-1" },
+          { type: "md5", checksum: "md5-1" },
+        ],
+      }),
+    ];
+
+    const result = buildChecksumFileContent(files, "sha256");
+    expect(result).toBe("sha-1  file1.c4gh\n");
+    expect(result).not.toContain("md5-1");
+  });
+
+  it("skips files that don't have the requested checksum type", () => {
+    const files = [
+      makeFile({
+        filePath: "file1.c4gh",
+        checksums: [{ type: "sha256", checksum: "sha-1" }],
+      }),
+      makeFile({
+        filePath: "file2.c4gh",
+        checksums: [{ type: "md5", checksum: "md5-2" }],
+      }),
+    ];
+
+    expect(buildChecksumFileContent(files, "sha256")).toBe(
+      "sha-1  file1.c4gh\n",
+    );
+  });
+
+  it("ends with exactly one trailing newline", () => {
+    const files = [
+      makeFile({
+        filePath: "file1.c4gh",
+        checksums: [{ type: "sha256", checksum: "abc" }],
+      }),
+    ];
+
+    const result = buildChecksumFileContent(files, "sha256");
+    expect(result.endsWith("\n")).toBe(true);
+    expect(result.endsWith("\n\n")).toBe(false);
+  });
+});

--- a/frontend/src/app/components/DownloadChecksumsButton.tsx
+++ b/frontend/src/app/components/DownloadChecksumsButton.tsx
@@ -1,31 +1,18 @@
 "use client";
 
 import { DatasetFile } from "../actions/datasets";
+import {
+  canExportChecksums,
+  createChecksumFileContent,
+  downloadTextFile,
+} from "../actions/checksums";
 
 export function pickChecksumType(
   files: DatasetFile[],
 ): "sha256" | "md5" | null {
-  const types = new Set(files.flatMap((f) => f.checksums.map((c) => c.type)));
-  if (types.has("sha256")) return "sha256";
-  if (types.has("md5")) return "md5";
+  if (canExportChecksums(files, "sha256")) return "sha256";
+  if (canExportChecksums(files, "md5")) return "md5";
   return null;
-}
-
-// Will create content in format "<checksum>  <filepath>" which is
-// compatible with sha256sum and md5sum CLI tools.
-export function buildChecksumFileContent(
-  files: DatasetFile[],
-  type: "sha256" | "md5",
-): string {
-  return (
-    files
-      .map((file) => {
-        const match = file.checksums.find((c) => c.type === type);
-        return match ? `${match.checksum}  ${file.filePath}` : null;
-      })
-      .filter((line): line is string => line !== null)
-      .join("\n") + "\n"
-  );
 }
 
 type DownloadChecksumsButtonProps = {
@@ -45,33 +32,20 @@ export default function DownloadChecksumsButton({
   const handleDownload = () => {
     if (!checksumType) return;
 
-    const content = buildChecksumFileContent(files, checksumType);
-    const blob = new Blob([content], { type: "text/plain" });
-    const url = URL.createObjectURL(blob);
-
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `${datasetId}_checksums.${checksumType}`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
+    const content = createChecksumFileContent(files, checksumType);
+    downloadTextFile(content, `${datasetId}_checksums.${checksumType}`);
   };
 
+  if (!checksumType) return null;
+
   return (
-    <>
-      {!checksumType ? (
-        <></>
-      ) : (
-        <button
-          type="button"
-          className="btn btn-primary align-self-start"
-          onClick={handleDownload}
-          title={`Download ${checksumType} checksums`}
-        >
-          Download checksums
-        </button>
-      )}
-    </>
+    <button
+      type="button"
+      className="btn btn-primary align-self-start"
+      onClick={handleDownload}
+      title={`Download ${checksumType} checksums`}
+    >
+      Download checksums
+    </button>
   );
 }

--- a/frontend/src/app/components/DownloadChecksumsButton.tsx
+++ b/frontend/src/app/components/DownloadChecksumsButton.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { DatasetFile } from "../actions/datasets";
+
+type DownloadChecksumsButtonProps = {
+  files: DatasetFile[];
+  datasetId: string;
+};
+
+export default function DownloadChecksumsButton({
+  files,
+  datasetId,
+}: DownloadChecksumsButtonProps) {
+  let availableTypes: string[] = [];
+  if (files && files.length > 0) {
+    availableTypes = [
+      ...new Set(files.flatMap((f) => f.checksums.map((c) => c.type))),
+    ];
+  }
+
+  let checksumType: string | null = null;
+  if (availableTypes.includes("sha256")) {
+    checksumType = "sha256";
+  } else if (availableTypes.includes("md5")) {
+    checksumType = "md5";
+  } else {
+    checksumType = null;
+  }
+
+  const handleDownload = () => {
+    if (!checksumType) return;
+
+    // Will create content in format "<checksum>  <filepath>" which is
+    // compatible with sha256sum and md5sum CLI tools.
+    const content =
+      files
+        .map((file) => {
+          const match = file.checksums.find((c) => c.type === checksumType);
+          return match ? `${match.checksum}  ${file.filePath}` : null;
+        })
+        .filter((line): line is string => line !== null)
+        .join("\n") + "\n";
+
+    const blob = new Blob([content], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${datasetId}_checksums.${checksumType}`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <>
+      {!checksumType ? (
+        <></>
+      ) : (
+        <button
+          type="button"
+          className="btn btn-primary align-self-start"
+          onClick={handleDownload}
+          title={`Download ${checksumType} checksums`}
+        >
+          Download checksums
+        </button>
+      )}
+    </>
+  );
+}

--- a/frontend/src/app/components/DownloadChecksumsButton.tsx
+++ b/frontend/src/app/components/DownloadChecksumsButton.tsx
@@ -2,6 +2,32 @@
 
 import { DatasetFile } from "../actions/datasets";
 
+export function pickChecksumType(
+  files: DatasetFile[],
+): "sha256" | "md5" | null {
+  const types = new Set(files.flatMap((f) => f.checksums.map((c) => c.type)));
+  if (types.has("sha256")) return "sha256";
+  if (types.has("md5")) return "md5";
+  return null;
+}
+
+// Will create content in format "<checksum>  <filepath>" which is
+// compatible with sha256sum and md5sum CLI tools.
+export function buildChecksumFileContent(
+  files: DatasetFile[],
+  type: "sha256" | "md5",
+): string {
+  return (
+    files
+      .map((file) => {
+        const match = file.checksums.find((c) => c.type === type);
+        return match ? `${match.checksum}  ${file.filePath}` : null;
+      })
+      .filter((line): line is string => line !== null)
+      .join("\n") + "\n"
+  );
+}
+
 type DownloadChecksumsButtonProps = {
   files: DatasetFile[];
   datasetId: string;
@@ -11,36 +37,15 @@ export default function DownloadChecksumsButton({
   files,
   datasetId,
 }: DownloadChecksumsButtonProps) {
-  let availableTypes: string[] = [];
+  let checksumType: "sha256" | "md5" | null = null;
   if (files && files.length > 0) {
-    availableTypes = [
-      ...new Set(files.flatMap((f) => f.checksums.map((c) => c.type))),
-    ];
-  }
-
-  let checksumType: string | null = null;
-  if (availableTypes.includes("sha256")) {
-    checksumType = "sha256";
-  } else if (availableTypes.includes("md5")) {
-    checksumType = "md5";
-  } else {
-    checksumType = null;
+    checksumType = pickChecksumType(files);
   }
 
   const handleDownload = () => {
     if (!checksumType) return;
 
-    // Will create content in format "<checksum>  <filepath>" which is
-    // compatible with sha256sum and md5sum CLI tools.
-    const content =
-      files
-        .map((file) => {
-          const match = file.checksums.find((c) => c.type === checksumType);
-          return match ? `${match.checksum}  ${file.filePath}` : null;
-        })
-        .filter((line): line is string => line !== null)
-        .join("\n") + "\n";
-
+    const content = buildChecksumFileContent(files, checksumType);
     const blob = new Blob([content], { type: "text/plain" });
     const url = URL.createObjectURL(blob);
 


### PR DESCRIPTION
<!-- Remove sections from this template that are not used -->

## Related issue(s) and PR(s)

This PR closes #61

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change

<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)

## List of changes made

- added a DownloadChecksumsButton component
- connected the component with relevant files
--> allow for download of a dataset's all checksums with one click
- added unit tests for the helper function used in the component

## Testing

<!-- Please delete options that are not relevant -->

- go to a dataset details page
- click on the "Download checksums" button in the upper section
- the download of the file should be handled by the browser
- open the file on your computer and make sure the format is right
- look at the tests added in this PR and make sure they make sense

## Further comments

This current implementation only supports sha256 and md5 checksums as it was implicitly described in the issue. If none of these types exist, no button for Download-all appears. Would it make sense to support other types in any way, e.g create a simple txt-file that can be downloaded? What format should the file have in that case? 

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] All Acceptance Criteria (AC) Fulfilled and checked in the Related issue
