### PR TITLE
fix: keep nav item active on sub-pages

### DIFF
--- a/frontend/src/app/components/Header.tsx
+++ b/frontend/src/app/components/Header.tsx
@@ -51,7 +51,9 @@ export function Header() {
           >
             <ul className="navbar-nav text-center text-md-start mt-3 mt-md-0">
               {navLinks.map((link) => {
-                const isActive = pathname === link.href;
+                const isActive =
+                  pathname === link.href ||
+                  (link.href !== "/" && pathname.startsWith(link.href + "/"));
                 return (
                   <li className="nav-item" key={link.href}>
                     <Link


### PR DESCRIPTION
## Related issue(s) and PR(s)

This PR closes #109.

<!-- Include below a description of the bug and the proposed fix -->

## Bug description

<!-- Describe the bug and the cause of the issue if known -->
The header marked a nav item as active only on an exact path match
(`pathname === link.href`). On sub-pages such as a dataset detail page
(`/datasets/[datasetId]`), no nav item was highlighted, so users lost the
sense of which section they were in.

## Fix implemented

In `Header.tsx`, a nav item is now treated as active when the pathname
matches its `href` exactly **or** starts with it as a path prefix
(`pathname.startsWith(link.href + "/")`). The `link.href !== "/"` guard
prevents the home link from matching every route.

## Testing

<!-- Please include instructions on how to verify the fix -->


  1. Go to **Datasets** (`/datasets`) — "Datasets" is shown as active.
  2. Open a dataset detail page (`/datasets/EGAD...`).
  3. "Datasets" stays marked as active. ✅
  4. Confirm the **Home** (`/`) link is only active on `/`, not on other routes.

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
- [ ] Relevant tests have been added or updated
- [x] The fix has been verified manually, if applicable