### PR TITLE
Batch file download via tar bundle

### DIFF
--- a/frontend/src/app/api/datasets/[datasetId]/download.tar/route.test.ts
+++ b/frontend/src/app/api/datasets/[datasetId]/download.tar/route.test.ts
@@ -1,0 +1,415 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from "vitest";
+import { GET } from "./route";
+import { NextRequest } from "next/server";
+import type { SessionData } from "@/app/lib/SessionManager";
+
+const sdaBaseUrl = "http://test.local";
+
+vi.mock(import("next/server"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, connection: async () => {} };
+});
+vi.mock(import("server-only"), () => ({}));
+vi.mock(import("@/app/lib/config"), () => ({
+  getConfig: async () => ({ sdaBaseUrl, sessionSecretPath: "" }),
+}));
+
+const sessionState: { current: SessionData | null } = { current: null };
+vi.mock(import("@/app/lib/session"), () => ({
+  getSession: async () => sessionState.current,
+  createOrUpdateSession: async () => undefined,
+  getClaims: async () => ({}),
+}));
+
+type MockFile = {
+  fileId: string;
+  filePath: string;
+  size: number;
+  decryptedSize: number;
+  checksums: never[];
+  downloadUrl: string;
+};
+
+const datasetState: {
+  metadata: { datasetId: string; date: string; files: number; size: number };
+  files: MockFile[];
+  metadataError: Error | null;
+  filesError: Error | null;
+} = {
+  metadata: {
+    datasetId: "ds1",
+    date: "2024-01-01T00:00:00Z",
+    files: 2,
+    size: 30,
+  },
+  files: [],
+  metadataError: null,
+  filesError: null,
+};
+
+vi.mock(import("@/app/actions/datasets"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    fetchDatasetMetadata: async () => {
+      if (datasetState.metadataError) throw datasetState.metadataError;
+      return datasetState.metadata;
+    },
+    fetchDatasetFiles: async () => {
+      if (datasetState.filesError) throw datasetState.filesError;
+      return { files: datasetState.files, nextPageToken: null };
+    },
+  };
+});
+
+const validSession: SessionData = {
+  token: "tok",
+  publicKey: { key: "PUBKEY", pemChecksum: "pem123" },
+};
+
+const F1: MockFile = {
+  fileId: "f1",
+  filePath: "a/sample1.cram.c4gh",
+  size: 10,
+  decryptedSize: 5,
+  checksums: [],
+  downloadUrl: "",
+};
+const F2: MockFile = {
+  fileId: "f2",
+  filePath: "b/sample2.cram.c4gh",
+  size: 20,
+  decryptedSize: 10,
+  checksums: [],
+  downloadUrl: "",
+};
+
+const F1_HEADER = new Uint8Array([1, 2, 3, 4]);
+const F1_CONTENT = new Uint8Array(10).map((_, i) => 10 + i);
+const F2_HEADER = new Uint8Array([5, 6, 7, 8, 9]);
+const F2_CONTENT = new Uint8Array(20).map((_, i) => 50 + i);
+
+// Per file the layout is: ustar(512) + c4ghHeader + content + pad → 1024 each.
+// Two files + 1024-byte trailer = 3072.
+const TRAILER_START = 2048;
+const TOTAL = 3072;
+
+function installDefaultFetch() {
+  return vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    const method = (init?.method || "GET").toUpperCase();
+
+    if (url.endsWith("/files/f1/header") && method === "GET")
+      return Promise.resolve(
+        new Response(F1_HEADER, {
+          status: 200,
+          headers: { "content-length": String(F1_HEADER.length) },
+        }),
+      );
+    if (url.endsWith("/files/f2/header") && method === "GET")
+      return Promise.resolve(
+        new Response(F2_HEADER, {
+          status: 200,
+          headers: { "content-length": String(F2_HEADER.length) },
+        }),
+      );
+    if (url.endsWith("/files/f1/content") && method === "HEAD")
+      return Promise.resolve(
+        new Response(null, {
+          status: 200,
+          headers: { "content-length": String(F1_CONTENT.length) },
+        }),
+      );
+    if (url.endsWith("/files/f2/content") && method === "HEAD")
+      return Promise.resolve(
+        new Response(null, {
+          status: 200,
+          headers: { "content-length": String(F2_CONTENT.length) },
+        }),
+      );
+    if (url.endsWith("/files/f1/content") && method === "GET")
+      return Promise.resolve(new Response(F1_CONTENT, { status: 200 }));
+    if (url.endsWith("/files/f2/content") && method === "GET")
+      return Promise.resolve(new Response(F2_CONTENT, { status: 200 }));
+
+    return Promise.resolve(new Response("unmocked " + url, { status: 500 }));
+  });
+}
+
+function makeReq(opts: { fileIds?: string } = {}) {
+  const url = new URL("http://localhost/api/datasets/ds1/download.tar");
+  if (opts.fileIds !== undefined) url.searchParams.set("fileIds", opts.fileIds);
+  return {
+    req: new NextRequest(url),
+    params: Promise.resolve({ datasetId: "ds1" }),
+  };
+}
+
+async function readAll(stream: ReadableStream<Uint8Array> | null) {
+  if (!stream) return new Uint8Array(0);
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) chunks.push(value);
+  }
+  const total = chunks.reduce((a, c) => a + c.byteLength, 0);
+  const out = new Uint8Array(total);
+  let o = 0;
+  for (const c of chunks) {
+    out.set(c, o);
+    o += c.byteLength;
+  }
+  return out;
+}
+
+function readOctal(buf: Uint8Array, offset: number, len: number): number {
+  let end = offset + len;
+  for (let i = offset; i < offset + len; i++) {
+    if (buf[i] === 0 || buf[i] === 0x20) {
+      end = i;
+      break;
+    }
+  }
+  return parseInt(
+    new TextDecoder().decode(buf.subarray(offset, end)) || "0",
+    8,
+  );
+}
+
+describe("GET /api/datasets/[datasetId]/download.tar (step 1: no resume)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    sessionState.current = null;
+    datasetState.metadataError = null;
+    datasetState.filesError = null;
+    datasetState.files = [F1, F2];
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  // --- Auth / input validation (no upstream fetch happens) ---
+
+  test("401 when no session", async () => {
+    const { req, params } = makeReq();
+    const resp = await GET(req, { params });
+    expect(resp.status).toBe(401);
+    expect(resp.headers.get("cache-control")).toBe("no-store");
+    await expect(resp.json()).resolves.toMatchObject({ status: 401 });
+  });
+
+  test("400 when session has no public key", async () => {
+    sessionState.current = { token: "tok", publicKey: null };
+    const { req, params } = makeReq();
+    const resp = await GET(req, { params });
+    expect(resp.status).toBe(400);
+    await expect(resp.json()).resolves.toMatchObject({ status: 400 });
+  });
+
+  test("400 when fileIds query parameter is empty / whitespace-only", async () => {
+    sessionState.current = validSession;
+    const { req, params } = makeReq({ fileIds: " , ," });
+    const resp = await GET(req, { params });
+    expect(resp.status).toBe(400);
+  });
+
+  test("400 when fileIds exceeds the per-request maximum", async () => {
+    sessionState.current = validSession;
+    const ids = Array.from({ length: 1001 }, (_, i) => `f${i}`).join(",");
+    const { req, params } = makeReq({ fileIds: ids });
+    const resp = await GET(req, { params });
+    expect(resp.status).toBe(400);
+  });
+
+  test("400 when fileIds selection matches no files in dataset", async () => {
+    sessionState.current = validSession;
+    const { req, params } = makeReq({ fileIds: "does-not-exist" });
+    const resp = await GET(req, { params });
+    expect(resp.status).toBe(400);
+  });
+
+  test("400 when dataset has no files", async () => {
+    sessionState.current = validSession;
+    datasetState.files = [];
+    const { req, params } = makeReq();
+    const resp = await GET(req, { params });
+    expect(resp.status).toBe(400);
+  });
+
+  // --- Pre-stream upstream failures translate cleanly ---
+
+  test("502 when dataset metadata fetch fails before streaming starts", async () => {
+    sessionState.current = validSession;
+    datasetState.metadataError = new Error("backend down");
+    const { req, params } = makeReq();
+    const resp = await GET(req, { params });
+    expect(resp.status).toBe(502);
+    await expect(resp.json()).resolves.toMatchObject({
+      error: expect.stringContaining("backend down"),
+      status: 502,
+    });
+  });
+
+  test("502 when dataset files fetch fails before streaming starts", async () => {
+    sessionState.current = validSession;
+    datasetState.filesError = new Error("files unavailable");
+    const { req, params } = makeReq();
+    const resp = await GET(req, { params });
+    expect(resp.status).toBe(502);
+    await expect(resp.json()).resolves.toMatchObject({ status: 502 });
+  });
+
+  // --- Happy path: full archive layout ---
+
+  test("returns 200 with the right response headers", async () => {
+    sessionState.current = validSession;
+    installDefaultFetch();
+    const { req, params } = makeReq();
+    const resp = await GET(req, { params });
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("content-type")).toBe("application/x-tar");
+    expect(resp.headers.get("cache-control")).toBe("no-store");
+    expect(resp.headers.get("content-disposition")).toContain(
+      'filename="ds1.tar"',
+    );
+  });
+
+  test("streams a deterministic full archive with c4gh header + content at known offsets", async () => {
+    sessionState.current = validSession;
+    installDefaultFetch();
+    const { req, params } = makeReq();
+    const resp = await GET(req, { params });
+    const body = await readAll(resp.body);
+
+    expect(body.byteLength).toBe(TOTAL);
+
+    // f1: ustar(0..512) | c4ghHeader(512..516) | content(516..526) | pad(526..1024)
+    expect(body.subarray(512, 516)).toEqual(F1_HEADER);
+    expect(body.subarray(516, 526)).toEqual(F1_CONTENT);
+    expect(body[526]).toBe(0);
+    expect(body[1023]).toBe(0);
+
+    // f2: ustar(1024..1536) | c4ghHeader(1536..1541) | content(1541..1561) | pad(1561..2048)
+    expect(body.subarray(1536, 1541)).toEqual(F2_HEADER);
+    expect(body.subarray(1541, 1561)).toEqual(F2_CONTENT);
+
+    // trailer: 1024 zero bytes
+    expect(body.subarray(TRAILER_START)).toEqual(new Uint8Array(1024));
+  });
+
+  test("ustar headers carry the correct file path and combined (header+content) size", async () => {
+    sessionState.current = validSession;
+    installDefaultFetch();
+    const { req, params } = makeReq();
+    const resp = await GET(req, { params });
+    const body = await readAll(resp.body);
+
+    const f1Name = new TextDecoder().decode(body.subarray(0, F1.filePath.length));
+    expect(f1Name).toBe(F1.filePath);
+    expect(readOctal(body, 124, 12)).toBe(F1_HEADER.length + F1_CONTENT.length);
+
+    const f2Name = new TextDecoder().decode(
+      body.subarray(1024, 1024 + F2.filePath.length),
+    );
+    expect(f2Name).toBe(F2.filePath);
+    expect(readOctal(body, 1024 + 124, 12)).toBe(
+      F2_HEADER.length + F2_CONTENT.length,
+    );
+  });
+
+  test("ustar mtime is derived from dataset.date", async () => {
+    sessionState.current = validSession;
+    installDefaultFetch();
+    const { req, params } = makeReq();
+    const resp = await GET(req, { params });
+    const body = await readAll(resp.body);
+    const expectedMtime = Math.floor(
+      new Date(datasetState.metadata.date).getTime() / 1000,
+    );
+    expect(readOctal(body, 136, 12)).toBe(expectedMtime);
+    expect(readOctal(body, 1024 + 136, 12)).toBe(expectedMtime);
+  });
+
+  // --- Determinism & selection ---
+
+  test("entries are emitted in alphabetical order by filePath regardless of upstream order", async () => {
+    sessionState.current = validSession;
+    datasetState.files = [F2, F1]; // reversed in mock
+    installDefaultFetch();
+    const { req, params } = makeReq();
+    const resp = await GET(req, { params });
+    const body = await readAll(resp.body);
+
+    // f1 ("a/...") must precede f2 ("b/...") in the emitted archive.
+    expect(body.subarray(512, 516)).toEqual(F1_HEADER);
+    expect(body.subarray(1536, 1541)).toEqual(F2_HEADER);
+  });
+
+  test("repeated invocations produce byte-identical archives", async () => {
+    sessionState.current = validSession;
+    installDefaultFetch();
+    const first = await readAll(
+      (await GET(makeReq().req, { params: makeReq().params })).body,
+    );
+    const second = await readAll(
+      (await GET(makeReq().req, { params: makeReq().params })).body,
+    );
+    expect(first).toEqual(second);
+  });
+
+  test("fileIds selection filters the archive to a single entry", async () => {
+    sessionState.current = validSession;
+    installDefaultFetch();
+    const { req, params } = makeReq({ fileIds: "f2" });
+    const resp = await GET(req, { params });
+    expect(resp.status).toBe(200);
+
+    const body = await readAll(resp.body);
+    // single entry (1024) + trailer (1024) = 2048
+    expect(body.byteLength).toBe(2048);
+    expect(body.subarray(512, 517)).toEqual(F2_HEADER);
+    expect(body.subarray(517, 537)).toEqual(F2_CONTENT);
+  });
+
+  // --- Outgoing request shape ---
+
+  test("sends the recipient public key only on /header requests", async () => {
+    sessionState.current = validSession;
+    const spy = installDefaultFetch();
+    const { req, params } = makeReq();
+    await readAll((await GET(req, { params })).body);
+
+    const calls = spy.mock.calls.map(([input, init]) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : (input as Request).url;
+      return {
+        url,
+        method: (init?.method || "GET").toUpperCase(),
+        headers: new Headers(init?.headers),
+      };
+    });
+
+    const headerCalls = calls.filter((c) => c.url.endsWith("/header"));
+    expect(headerCalls.length).toBeGreaterThan(0);
+    for (const c of headerCalls) {
+      expect(c.headers.get("authorization")).toBe("Bearer tok");
+      expect(c.headers.get("x-c4gh-public-key")).toBe("PUBKEY");
+    }
+
+    const contentCalls = calls.filter((c) => c.url.endsWith("/content"));
+    expect(contentCalls.length).toBeGreaterThan(0);
+    for (const c of contentCalls) {
+      expect(c.headers.get("authorization")).toBe("Bearer tok");
+      expect(c.headers.get("x-c4gh-public-key")).toBeNull();
+    }
+  });
+});

--- a/frontend/src/app/api/datasets/[datasetId]/download.tar/route.test.ts
+++ b/frontend/src/app/api/datasets/[datasetId]/download.tar/route.test.ts
@@ -94,6 +94,34 @@ const F2_CONTENT = new Uint8Array(20).map((_, i) => 50 + i);
 const TRAILER_START = 2048;
 const TOTAL = 3072;
 
+function defaultUpstream(url: string, method: string): Response {
+  if (url.endsWith("/files/f1/header") && method === "GET")
+    return new Response(F1_HEADER, {
+      status: 200,
+      headers: { "content-length": String(F1_HEADER.length) },
+    });
+  if (url.endsWith("/files/f2/header") && method === "GET")
+    return new Response(F2_HEADER, {
+      status: 200,
+      headers: { "content-length": String(F2_HEADER.length) },
+    });
+  if (url.endsWith("/files/f1/content") && method === "HEAD")
+    return new Response(null, {
+      status: 200,
+      headers: { "content-length": String(F1_CONTENT.length) },
+    });
+  if (url.endsWith("/files/f2/content") && method === "HEAD")
+    return new Response(null, {
+      status: 200,
+      headers: { "content-length": String(F2_CONTENT.length) },
+    });
+  if (url.endsWith("/files/f1/content") && method === "GET")
+    return new Response(F1_CONTENT, { status: 200 });
+  if (url.endsWith("/files/f2/content") && method === "GET")
+    return new Response(F2_CONTENT, { status: 200 });
+  return new Response("unmocked " + url, { status: 500 });
+}
+
 function installDefaultFetch() {
   return vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
     const url =
@@ -103,41 +131,7 @@ function installDefaultFetch() {
           ? input.toString()
           : (input as Request).url;
     const method = (init?.method || "GET").toUpperCase();
-
-    if (url.endsWith("/files/f1/header") && method === "GET")
-      return Promise.resolve(
-        new Response(F1_HEADER, {
-          status: 200,
-          headers: { "content-length": String(F1_HEADER.length) },
-        }),
-      );
-    if (url.endsWith("/files/f2/header") && method === "GET")
-      return Promise.resolve(
-        new Response(F2_HEADER, {
-          status: 200,
-          headers: { "content-length": String(F2_HEADER.length) },
-        }),
-      );
-    if (url.endsWith("/files/f1/content") && method === "HEAD")
-      return Promise.resolve(
-        new Response(null, {
-          status: 200,
-          headers: { "content-length": String(F1_CONTENT.length) },
-        }),
-      );
-    if (url.endsWith("/files/f2/content") && method === "HEAD")
-      return Promise.resolve(
-        new Response(null, {
-          status: 200,
-          headers: { "content-length": String(F2_CONTENT.length) },
-        }),
-      );
-    if (url.endsWith("/files/f1/content") && method === "GET")
-      return Promise.resolve(new Response(F1_CONTENT, { status: 200 }));
-    if (url.endsWith("/files/f2/content") && method === "GET")
-      return Promise.resolve(new Response(F2_CONTENT, { status: 200 }));
-
-    return Promise.resolve(new Response("unmocked " + url, { status: 500 }));
+    return Promise.resolve(defaultUpstream(url, method));
   });
 }
 
@@ -183,7 +177,7 @@ function readOctal(buf: Uint8Array, offset: number, len: number): number {
   );
 }
 
-describe("GET /api/datasets/[datasetId]/download.tar (step 1: no resume)", () => {
+describe("GET /api/datasets/[datasetId]/download.tar", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     sessionState.current = null;
@@ -411,5 +405,143 @@ describe("GET /api/datasets/[datasetId]/download.tar (step 1: no resume)", () =>
       expect(c.headers.get("authorization")).toBe("Bearer tok");
       expect(c.headers.get("x-c4gh-public-key")).toBeNull();
     }
+  });
+
+  // --- Content-Length (advertised total) -----------------------------------
+
+  test("advertises Content-Length equal to the full archive size", async () => {
+    sessionState.current = validSession;
+    installDefaultFetch();
+    const { req, params } = makeReq();
+    const resp = await GET(req, { params });
+    expect(resp.headers.get("content-length")).toBe(String(TOTAL));
+
+    // And the body actually delivers that many bytes.
+    const body = await readAll(resp.body);
+    expect(body.byteLength).toBe(TOTAL);
+  });
+
+  test("Content-Length adjusts to the selection", async () => {
+    sessionState.current = validSession;
+    installDefaultFetch();
+    const { req, params } = makeReq({ fileIds: "f2" });
+    const resp = await GET(req, { params });
+    // single entry (1024) + trailer (1024) = 2048
+    expect(resp.headers.get("content-length")).toBe("2048");
+  });
+
+  // --- Preflight surfaces real upstream status, not a blanket 502 ----------
+
+  test("forwards the upstream status when /header GET fails during preflight", async () => {
+    sessionState.current = validSession;
+    vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : (input as Request).url;
+      const method = (init?.method || "GET").toUpperCase();
+
+      if (url.endsWith("/files/f1/header") && method === "GET") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              title: "Forbidden",
+              status: 403,
+              detail: "No access to this file.",
+            }),
+            {
+              status: 403,
+              headers: { "content-type": "application/problem+json" },
+            },
+          ),
+        );
+      }
+      // everything else: default behaviour
+      return Promise.resolve(defaultUpstream(url, method));
+    });
+
+    const { req, params } = makeReq();
+    const resp = await GET(req, { params });
+    expect(resp.status).toBe(403);
+    await expect(resp.json()).resolves.toMatchObject({
+      error: "No access to this file.",
+      status: 403,
+    });
+  });
+
+  test("forwards the upstream status when /content HEAD fails during preflight", async () => {
+    sessionState.current = validSession;
+    vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : (input as Request).url;
+      const method = (init?.method || "GET").toUpperCase();
+
+      if (url.endsWith("/files/f2/content") && method === "HEAD") {
+        return Promise.resolve(new Response("nope", { status: 500 }));
+      }
+      return Promise.resolve(defaultUpstream(url, method));
+    });
+
+    const { req, params } = makeReq();
+    const resp = await GET(req, { params });
+    expect(resp.status).toBe(500);
+    await expect(resp.json()).resolves.toMatchObject({ status: 500 });
+  });
+
+  test("502 when the preflight fetch itself rejects (network failure)", async () => {
+    sessionState.current = validSession;
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+    const { req, params } = makeReq();
+    const resp = await GET(req, { params });
+    expect(resp.status).toBe(502);
+    await expect(resp.json()).resolves.toMatchObject({
+      error: expect.stringContaining("ECONNREFUSED"),
+      status: 502,
+    });
+  });
+
+  // --- Mid-stream content shortfall is treated as a failure ----------------
+
+  test("aborts the stream when /content delivers fewer bytes than HEAD advertised", async () => {
+    sessionState.current = validSession;
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : (input as Request).url;
+      const method = (init?.method || "GET").toUpperCase();
+
+      // /content HEAD claims F1_CONTENT.length, but the GET delivers half.
+      if (url.endsWith("/files/f1/content") && method === "GET") {
+        return Promise.resolve(
+          new Response(F1_CONTENT.subarray(0, F1_CONTENT.length / 2), {
+            status: 200,
+          }),
+        );
+      }
+      return Promise.resolve(defaultUpstream(url, method));
+    });
+
+    const { req, params } = makeReq();
+    const resp = await GET(req, { params });
+    // Status/headers already flushed when the mismatch was detected.
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("content-length")).toBe(String(TOTAL));
+    // …but the stream is torn down, so the consumer sees an error.
+    await expect(readAll(resp.body)).rejects.toThrow();
+
+    expect(consoleError).toHaveBeenCalledWith(
+    expect.stringContaining("tar:ds1:stream error"),
+    expect.any(Error),
+  );
   });
 });

--- a/frontend/src/app/api/datasets/[datasetId]/download.tar/route.test.ts
+++ b/frontend/src/app/api/datasets/[datasetId]/download.tar/route.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi, beforeEach, afterEach } from "vitest";
 import { GET } from "./route";
 import { NextRequest } from "next/server";
 import type { SessionData } from "@/app/lib/SessionManager";
+import { MAX_TAR_SELECTION } from "@/app/lib/constants";
 
 const sdaBaseUrl = "http://test.local";
 
@@ -214,10 +215,36 @@ describe("GET /api/datasets/[datasetId]/download.tar", () => {
 
   test("400 when fileIds exceeds the per-request maximum", async () => {
     sessionState.current = validSession;
-    const ids = Array.from({ length: 1001 }, (_, i) => `f${i}`).join(",");
+    const ids = Array.from(
+      { length: MAX_TAR_SELECTION + 1 },
+      (_, i) => `f${i}`,
+    ).join(",");
     const { req, params } = makeReq({ fileIds: ids });
     const resp = await GET(req, { params });
     expect(resp.status).toBe(400);
+  });
+
+  test("400 when the whole dataset exceeds the per-request maximum", async () => {
+    sessionState.current = validSession;
+    // No fileIds → archive every file. Make the dataset bigger than the cap.
+    datasetState.files = Array.from(
+      { length: MAX_TAR_SELECTION + 1 },
+      (_, i) => ({
+        fileId: `f${i}`,
+        filePath: `path/${i}.c4gh`,
+        size: 1,
+        decryptedSize: 1,
+        checksums: [],
+        downloadUrl: "",
+      }),
+    );
+    const { req, params } = makeReq();
+    const resp = await GET(req, { params });
+    expect(resp.status).toBe(400);
+    await expect(resp.json()).resolves.toMatchObject({
+      error: expect.stringContaining(`capped at ${MAX_TAR_SELECTION}`),
+      status: 400,
+    });
   });
 
   test("400 when fileIds selection matches no files in dataset", async () => {

--- a/frontend/src/app/api/datasets/[datasetId]/download.tar/route.test.ts
+++ b/frontend/src/app/api/datasets/[datasetId]/download.tar/route.test.ts
@@ -548,4 +548,45 @@ describe("GET /api/datasets/[datasetId]/download.tar", () => {
       expect.any(Error),
     );
   });
+
+  test("aborts preflight upstream fetches when the client disconnects", async () => {
+    sessionState.current = validSession;
+
+    const ac = new AbortController();
+    const seenSignals: AbortSignal[] = [];
+
+    vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+      if (init?.signal) seenSignals.push(init.signal);
+
+      return new Promise<Response>((_, reject) => {
+        const signal = init?.signal;
+        if (!signal) return; // never resolves; we want this to fail loudly if it ever happens
+        const onAbort = () => {
+          const err = new Error("aborted") as Error & { name: string };
+          err.name = "AbortError";
+          reject(err);
+        };
+        if (signal.aborted) return onAbort();
+        signal.addEventListener("abort", onAbort, { once: true });
+      });
+    });
+
+    const url = new URL("http://localhost/api/datasets/ds1/download.tar");
+    const req = new NextRequest(url, { signal: ac.signal });
+    const params = Promise.resolve({ datasetId: "ds1" });
+
+    const pending = GET(req, { params });
+    ac.abort();
+
+    const resp = await pending;
+    expect(resp.status).toBe(400);
+
+    // At least one upstream fetch was made and every one of them
+    // received a signal that aborts when the client request aborts.
+    expect(seenSignals.length).toBeGreaterThan(0);
+    for (const s of seenSignals) {
+      expect(s).toBeInstanceOf(AbortSignal);
+      expect(s.aborted).toBe(true);
+    }
+  });
 });

--- a/frontend/src/app/api/datasets/[datasetId]/download.tar/route.test.ts
+++ b/frontend/src/app/api/datasets/[datasetId]/download.tar/route.test.ts
@@ -303,7 +303,9 @@ describe("GET /api/datasets/[datasetId]/download.tar", () => {
     const resp = await GET(req, { params });
     const body = await readAll(resp.body);
 
-    const f1Name = new TextDecoder().decode(body.subarray(0, F1.filePath.length));
+    const f1Name = new TextDecoder().decode(
+      body.subarray(0, F1.filePath.length),
+    );
     expect(f1Name).toBe(F1.filePath);
     expect(readOctal(body, 124, 12)).toBe(F1_HEADER.length + F1_CONTENT.length);
 
@@ -510,7 +512,9 @@ describe("GET /api/datasets/[datasetId]/download.tar", () => {
 
   test("aborts the stream when /content delivers fewer bytes than HEAD advertised", async () => {
     sessionState.current = validSession;
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
     vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
       const url =
         typeof input === "string"
@@ -540,8 +544,8 @@ describe("GET /api/datasets/[datasetId]/download.tar", () => {
     await expect(readAll(resp.body)).rejects.toThrow();
 
     expect(consoleError).toHaveBeenCalledWith(
-    expect.stringContaining("tar:ds1:stream error"),
-    expect.any(Error),
-  );
+      expect.stringContaining("tar:ds1:stream error"),
+      expect.any(Error),
+    );
   });
 });

--- a/frontend/src/app/api/datasets/[datasetId]/download.tar/route.ts
+++ b/frontend/src/app/api/datasets/[datasetId]/download.tar/route.ts
@@ -53,6 +53,7 @@ export async function GET(
   }
 
   const fileIdsParam = request.nextUrl.searchParams.get("fileIds");
+  // The selectedFileIds == null case is left here to wire a full dataset download later.
   let selectedFileIds: Set<string> | null = null;
   if (fileIdsParam !== null) {
     const ids = fileIdsParam
@@ -94,9 +95,10 @@ export async function GET(
     selectedFileIds
       ? allFiles.filter((f) => selectedFileIds!.has(f.fileId))
       : allFiles
-  ).sort((a, b) =>
-    a.filePath < b.filePath ? -1 : a.filePath > b.filePath ? 1 : 0,
-  );
+  ) // The selectedFileIds == null case is left here to wire a full dataset download later.
+    .sort((a, b) =>
+      a.filePath < b.filePath ? -1 : a.filePath > b.filePath ? 1 : 0,
+    );
 
   if (files.length === 0) {
     return errorResponse(

--- a/frontend/src/app/api/datasets/[datasetId]/download.tar/route.ts
+++ b/frontend/src/app/api/datasets/[datasetId]/download.tar/route.ts
@@ -1,0 +1,226 @@
+import { NextRequest } from "next/server";
+import { Readable } from "node:stream";
+import { getSession } from "@/app/lib/session";
+import { getConfig } from "@/app/lib/config";
+import {
+  fetchDatasetMetadata,
+  fetchDatasetFiles,
+  fetchAll,
+  type DatasetFile,
+  type DatasetMetadata,
+} from "@/app/actions/datasets";
+import {
+  errorResponse,
+  extractProblemDetail,
+  translateUpstreamError,
+  buildContentDisposition,
+} from "@/app/lib/proxy";
+import { planEntry, TAR_BLOCK_SIZE, TAR_TRAILER_LEN } from "@/app/lib/tar";
+
+// Node runtime gives us a real Node Readable, which Next.js streams to the
+// socket without coalescing. The Web ReadableStream path is fine here too,
+// but using Node lets us share the same plumbing with step 2.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const MAX_SELECTED_FILE_IDS = 1000;
+const TRAILER = new Uint8Array(TAR_TRAILER_LEN);
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ datasetId: string }> },
+) {
+  const { datasetId } = await params;
+
+  const sessionData = await getSession();
+  if (!sessionData?.token) return errorResponse(401, "Not authenticated.");
+  if (!sessionData.publicKey?.key) {
+    return errorResponse(
+      400,
+      "No Crypt4GH public key configured. Upload your public key on the profile page before downloading files.",
+    );
+  }
+
+  const fileIdsParam = request.nextUrl.searchParams.get("fileIds");
+  let selectedFileIds: Set<string> | null = null;
+  if (fileIdsParam !== null) {
+    const ids = fileIdsParam
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    if (ids.length === 0) {
+      return errorResponse(400, "fileIds query parameter is empty.");
+    }
+    if (ids.length > MAX_SELECTED_FILE_IDS) {
+      return errorResponse(
+        400,
+        `Too many fileIds; maximum is ${MAX_SELECTED_FILE_IDS}.`,
+      );
+    }
+    selectedFileIds = new Set(ids);
+  }
+
+  const { sdaBaseUrl } = await getConfig();
+  const token = sessionData.token;
+  const publicKey = sessionData.publicKey.key;
+
+  let dataset: DatasetMetadata;
+  let allFiles: DatasetFile[];
+  try {
+    dataset = await fetchDatasetMetadata(token, datasetId);
+    allFiles = await fetchAll(async (pageToken) => {
+      const page = await fetchDatasetFiles(token, datasetId, pageToken);
+      return { items: page.files, nextPageToken: page.nextPageToken };
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Unknown error occurred";
+    return errorResponse(502, `Could not reach the download backend: ${msg}`);
+  }
+
+  // We need a deterministic order for the files to ensure a stable TAR layout and ETag (for resuming),
+  // here we chose to sort by filePath but any deterministic order should work work.
+  const files = (
+    selectedFileIds
+      ? allFiles.filter((f) => selectedFileIds!.has(f.fileId))
+      : allFiles
+  ).sort((a, b) =>
+    a.filePath < b.filePath ? -1 : a.filePath > b.filePath ? 1 : 0,
+  );
+
+  if (files.length === 0) {
+    return errorResponse(
+      400,
+      selectedFileIds
+        ? "No files match the requested fileIds."
+        : "Dataset has no files to download.",
+    );
+  }
+
+  // needed for TAR header "mtime" field; using dataset creation date
+  const datasetEpoch = new Date(dataset.date).getTime();
+  const mtime =
+    Number.isFinite(datasetEpoch) && datasetEpoch >= 0
+      ? Math.floor(datasetEpoch / 1000)
+      : 0;
+
+  async function* emitTar(): AsyncGenerator<Buffer> {
+    for (const file of files) {
+      const headerUrl = `${sdaBaseUrl}/files/${encodeURIComponent(file.fileId)}/header`;
+      const contentUrl = `${sdaBaseUrl}/files/${encodeURIComponent(file.fileId)}/content`;
+
+      // re-encrypted header (small, fully buffered)
+      const headerResp = await fetch(headerUrl, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "X-C4GH-Public-Key": publicKey,
+        },
+        cache: "no-store",
+      });
+      if (!headerResp.ok) {
+        throw new Error(
+          `Failed to fetch header for ${file.fileId}: ${headerResp.status}`,
+        );
+      }
+      const headerBytes = new Uint8Array(await headerResp.arrayBuffer());
+
+      // 2) HEAD content for size
+      const contentHead = await fetch(contentUrl, {
+        method: "HEAD",
+        headers: { Authorization: `Bearer ${token}` },
+        cache: "no-store",
+      });
+      if (!contentHead.ok) {
+        throw new Error(
+          `Failed to HEAD content for ${file.fileId}: ${contentHead.status}`,
+        );
+      }
+      const contentLen = parseInt(
+        contentHead.headers.get("content-length") || "0",
+        10,
+      );
+
+      // Plan + emit TAR header block(s)
+      const fileDataLen = headerBytes.byteLength + contentLen;
+      const plan = planEntry(file.filePath, fileDataLen, mtime);
+      if (plan.paxBlock) yield Buffer.from(plan.paxBlock);
+      yield Buffer.from(plan.ustarBlock);
+
+      // Emit the c4gh header bytes
+      if (headerBytes.byteLength > 0) yield Buffer.from(headerBytes);
+
+      // Stream the c4gh content body straight through
+      const contentResp = await fetch(contentUrl, {
+        headers: { Authorization: `Bearer ${token}` },
+        cache: "no-store",
+      });
+      if (!contentResp.ok || !contentResp.body) {
+        throw new Error(
+          `Failed to GET content for ${file.fileId}: ${contentResp.status}`,
+        );
+      }
+      const reader = contentResp.body.getReader();
+      let streamed = 0;
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (value && value.byteLength > 0) {
+            streamed += value.byteLength;
+            yield Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+          }
+        }
+      } finally {
+        try {
+          await reader.cancel();
+        } catch {
+          // best-effort
+        }
+      }
+      if (streamed !== contentLen) {
+        throw new Error(
+          `Content length mismatch for ${file.fileId}: expected ${contentLen}, got ${streamed}`,
+        );
+      }
+
+      // Pad to a 512-byte boundary
+      if (plan.paddingLen > 0) yield Buffer.alloc(plan.paddingLen);
+    }
+
+    // TAR trailer: two zero blocks
+    yield Buffer.from(TRAILER);
+  }
+
+  // Readable.from pulls from the generator on demand. If the browser slows
+  // down receiving the TAR, the socket fills up, Node stops asking the
+  // generator for more, and the generator stops fetching from upstream.
+  // We get end-to-end backpressure without any manual buffering logic.
+  const nodeReadable = Readable.from(emitTar(), {
+    highWaterMark: 256 * 1024,
+  });
+
+  // Surface any upstream failure mid-stream by tearing the response down.
+  // We can't change the HTTP status by this point but at least the client
+  // won't receive a truncated TAR that looks complete.
+  nodeReadable.on("error", (err) => {
+    console.error(`tar:${datasetId}:stream error`, err);
+  });
+
+  // These are placeholders for handling mid-stream errors more gracefully in the future.
+  // The idea is to leave this for the resuming functionality.
+  // Checks before the stream opens are in-place already.
+  void extractProblemDetail;
+  void translateUpstreamError;
+
+  const webStream = Readable.toWeb(
+    nodeReadable,
+  ) as unknown as ReadableStream<Uint8Array>;
+
+  return new Response(webStream, {
+    status: 200,
+    headers: {
+      "content-type": "application/x-tar",
+      "cache-control": "no-store",
+      "content-disposition": buildContentDisposition(`${datasetId}.tar`),
+    },
+  });
+}

--- a/frontend/src/app/api/datasets/[datasetId]/download.tar/route.ts
+++ b/frontend/src/app/api/datasets/[datasetId]/download.tar/route.ts
@@ -41,6 +41,7 @@ export async function GET(
   { params }: { params: Promise<{ datasetId: string }> },
 ) {
   const { datasetId } = await params;
+  const signal = request.signal;
 
   const sessionData = await getSession();
   if (!sessionData?.token) return errorResponse(401, "Not authenticated.");
@@ -118,9 +119,20 @@ export async function GET(
   // total TAR length so we can advertise Content-Length to the browser.
   let resolved: ResolvedEntry[];
   try {
-    resolved = await probeAll({ files, token, publicKey, sdaBaseUrl, mtime });
+    resolved = await probeAll({
+      files,
+      token,
+      publicKey,
+      sdaBaseUrl,
+      mtime,
+      signal,
+    });
   } catch (e) {
     if (e instanceof Response) return e;
+
+    if (signal.aborted) {
+      return new Response(null, { status: 400 });
+    }
 
     const msg = e instanceof Error ? e.message : "Unknown error occurred";
     return errorResponse(502, `Could not reach the download backend: ${msg}`);
@@ -142,6 +154,7 @@ export async function GET(
       const contentResp = await fetch(contentUrl, {
         headers: { Authorization: `Bearer ${token}` },
         cache: "no-store",
+        signal,
       });
       if (!contentResp.ok || !contentResp.body) {
         throw new Error(
@@ -192,6 +205,10 @@ export async function GET(
   // We can't change the HTTP status by this point but at least the client
   // won't receive a truncated TAR that looks complete.
   nodeReadable.on("error", (err) => {
+    if ((err as { name?: string })?.name === "AbortError" || signal.aborted) {
+      // Client disconnected mid-stream; not actionable.
+      return;
+    }
     console.error(`tar:${datasetId}:stream error`, err);
   });
 
@@ -218,8 +235,9 @@ async function probeAll(opts: {
   publicKey: string;
   sdaBaseUrl: string;
   mtime: number;
+  signal: AbortSignal;
 }): Promise<ResolvedEntry[]> {
-  const { files, token, publicKey, sdaBaseUrl, mtime } = opts;
+  const { files, token, publicKey, sdaBaseUrl, mtime, signal } = opts;
   const out: ResolvedEntry[] = new Array(files.length);
   let next = 0;
   const workerCount = Math.min(HEADER_FETCH_CONCURRENCY, files.length);
@@ -228,7 +246,14 @@ async function probeAll(opts: {
     for (;;) {
       const i = next++;
       if (i >= files.length) return;
-      out[i] = await probeOne(files[i], token, publicKey, sdaBaseUrl, mtime);
+      out[i] = await probeOne(
+        files[i],
+        token,
+        publicKey,
+        sdaBaseUrl,
+        mtime,
+        signal,
+      );
     }
   });
   await Promise.all(workers);
@@ -243,6 +268,7 @@ async function probeOne(
   publicKey: string,
   sdaBaseUrl: string,
   mtime: number,
+  signal: AbortSignal,
 ): Promise<ResolvedEntry> {
   const headerUrl = `${sdaBaseUrl}/files/${encodeURIComponent(file.fileId)}/header`;
   const contentUrl = `${sdaBaseUrl}/files/${encodeURIComponent(file.fileId)}/content`;
@@ -254,11 +280,13 @@ async function probeOne(
         "X-C4GH-Public-Key": publicKey,
       },
       cache: "no-store",
+      signal,
     }),
     fetch(contentUrl, {
       method: "HEAD",
       headers: { Authorization: `Bearer ${token}` },
       cache: "no-store",
+      signal,
     }),
   ]);
 

--- a/frontend/src/app/api/datasets/[datasetId]/download.tar/route.ts
+++ b/frontend/src/app/api/datasets/[datasetId]/download.tar/route.ts
@@ -15,16 +15,21 @@ import {
   translateUpstreamError,
   buildContentDisposition,
 } from "@/app/lib/proxy";
-import { planEntry, TAR_BLOCK_SIZE, TAR_TRAILER_LEN } from "@/app/lib/tar";
+import { planEntry, TAR_BLOCK_SIZE, TAR_TRAILER_LEN, type PlannedEntry } from "@/app/lib/tar";
 
-// Node runtime gives us a real Node Readable, which Next.js streams to the
-// socket without coalescing. The Web ReadableStream path is fine here too,
-// but using Node lets us share the same plumbing with step 2.
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+const HEADER_FETCH_CONCURRENCY = 32;
 const MAX_SELECTED_FILE_IDS = 1000;
 const TRAILER = new Uint8Array(TAR_TRAILER_LEN);
+
+type ResolvedEntry = {
+  file: DatasetFile;
+  headerBytes: Uint8Array;
+  contentLen: number;
+  plan: PlannedEntry;
+};
 
 export async function GET(
   request: NextRequest,
@@ -103,59 +108,38 @@ export async function GET(
       ? Math.floor(datasetEpoch / 1000)
       : 0;
 
+  // Preparation before opening the stream. GET each header (small) + HEAD each /content
+  // with bounded concurrency. This gives us per-entry headerBytes (reused later) and the
+  // total TAR length so we can advertise Content-Length to the browser.
+  let resolved: ResolvedEntry[];
+  try {
+    resolved = await probeAll({files, token, publicKey, sdaBaseUrl, mtime});
+  } catch (e) {
+    if (e instanceof Response) return e;
+
+    const msg = e instanceof Error ? e.message : "Unknown error occurred";
+    return errorResponse(502, `Could not reach the download backend: ${msg}`);
+  }
+
+  const totalLen = resolved.reduce((sum, r) => sum + r.plan.entryLen, 0) + TAR_TRAILER_LEN;
+
   async function* emitTar(): AsyncGenerator<Buffer> {
-    for (const file of files) {
-      const headerUrl = `${sdaBaseUrl}/files/${encodeURIComponent(file.fileId)}/header`;
-      const contentUrl = `${sdaBaseUrl}/files/${encodeURIComponent(file.fileId)}/content`;
+    for (const r of resolved) {
+      if (r.plan.paxBlock) yield Buffer.from(r.plan.paxBlock);
+      yield Buffer.from(r.plan.ustarBlock);
 
-      // re-encrypted header (small, fully buffered)
-      const headerResp = await fetch(headerUrl, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "X-C4GH-Public-Key": publicKey,
-        },
-        cache: "no-store",
-      });
-      if (!headerResp.ok) {
-        throw new Error(
-          `Failed to fetch header for ${file.fileId}: ${headerResp.status}`,
-        );
-      }
-      const headerBytes = new Uint8Array(await headerResp.arrayBuffer());
+      // Use the c4gh header bytes we already have from preparatory phase.
+      if (r.headerBytes.byteLength > 0) yield Buffer.from(r.headerBytes);
 
-      // 2) HEAD content for size
-      const contentHead = await fetch(contentUrl, {
-        method: "HEAD",
-        headers: { Authorization: `Bearer ${token}` },
-        cache: "no-store",
-      });
-      if (!contentHead.ok) {
-        throw new Error(
-          `Failed to HEAD content for ${file.fileId}: ${contentHead.status}`,
-        );
-      }
-      const contentLen = parseInt(
-        contentHead.headers.get("content-length") || "0",
-        10,
-      );
-
-      // Plan + emit TAR header block(s)
-      const fileDataLen = headerBytes.byteLength + contentLen;
-      const plan = planEntry(file.filePath, fileDataLen, mtime);
-      if (plan.paxBlock) yield Buffer.from(plan.paxBlock);
-      yield Buffer.from(plan.ustarBlock);
-
-      // Emit the c4gh header bytes
-      if (headerBytes.byteLength > 0) yield Buffer.from(headerBytes);
-
-      // Stream the c4gh content body straight through
+      // Stream the content, verify the content length here to ensure data integrity.
+      const contentUrl = `${sdaBaseUrl}/files/${encodeURIComponent(r.file.fileId)}/content`;
       const contentResp = await fetch(contentUrl, {
         headers: { Authorization: `Bearer ${token}` },
         cache: "no-store",
       });
       if (!contentResp.ok || !contentResp.body) {
         throw new Error(
-          `Failed to GET content for ${file.fileId}: ${contentResp.status}`,
+          `Failed to GET content for ${r.file.fileId}: ${contentResp.status}`,
         );
       }
       const reader = contentResp.body.getReader();
@@ -176,16 +160,16 @@ export async function GET(
           // best-effort
         }
       }
-      if (streamed !== contentLen) {
+      if (streamed !== r.contentLen) {
         throw new Error(
-          `Content length mismatch for ${file.fileId}: expected ${contentLen}, got ${streamed}`,
+          `Content length mismatch for ${r.file.fileId}: expected ${r.contentLen}, got ${streamed}`,
         );
       }
 
-      // Pad to a 512-byte boundary
-      if (plan.paddingLen > 0) yield Buffer.alloc(plan.paddingLen);
+      // Pad the entry to a 512-byte boundary so the next entry's header
+      // block starts on a clean offset (TAR requirement).
+      if (r.plan.paddingLen > 0) yield Buffer.alloc(r.plan.paddingLen);
     }
-
     // TAR trailer: two zero blocks
     yield Buffer.from(TRAILER);
   }
@@ -205,12 +189,6 @@ export async function GET(
     console.error(`tar:${datasetId}:stream error`, err);
   });
 
-  // These are placeholders for handling mid-stream errors more gracefully in the future.
-  // The idea is to leave this for the resuming functionality.
-  // Checks before the stream opens are in-place already.
-  void extractProblemDetail;
-  void translateUpstreamError;
-
   const webStream = Readable.toWeb(
     nodeReadable,
   ) as unknown as ReadableStream<Uint8Array>;
@@ -219,8 +197,88 @@ export async function GET(
     status: 200,
     headers: {
       "content-type": "application/x-tar",
+      "content-length": String(totalLen),
       "cache-control": "no-store",
       "content-disposition": buildContentDisposition(`${datasetId}.tar`),
     },
   });
+}
+
+// Run probeOne() over every file with bounded concurrency, preserving the
+// input order in the returned array.
+async function probeAll(opts: {
+  files: DatasetFile[];
+  token: string;
+  publicKey: string;
+  sdaBaseUrl: string;
+  mtime: number;
+}): Promise<ResolvedEntry[]> {
+  const { files, token, publicKey, sdaBaseUrl, mtime } = opts;
+  const out: ResolvedEntry[] = new Array(files.length);
+  let next = 0;
+  const workerCount = Math.min(HEADER_FETCH_CONCURRENCY, files.length);
+
+  const workers = Array.from({ length: workerCount }, async () => {
+    for (;;) {
+      const i = next++;
+      if (i >= files.length) return;
+      out[i] = await probeOne(files[i], token, publicKey, sdaBaseUrl, mtime);
+    }
+  });
+  await Promise.all(workers);
+  return out;
+}
+
+// Per file preparation before streaming: GET its re-encrypted Crypt4GH header and HEAD
+// its content. Combine the two into a ResolvedEntry that fully describes the file's TAR entry.
+async function probeOne(
+  file: DatasetFile,
+  token: string,
+  publicKey: string,
+  sdaBaseUrl: string,
+  mtime: number,
+): Promise<ResolvedEntry> {
+  const headerUrl = `${sdaBaseUrl}/files/${encodeURIComponent(file.fileId)}/header`;
+  const contentUrl = `${sdaBaseUrl}/files/${encodeURIComponent(file.fileId)}/content`;
+
+  const [headerResp, contentHead] = await Promise.all([
+    fetch(headerUrl, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "X-C4GH-Public-Key": publicKey,
+      },
+      cache: "no-store",
+    }),
+    fetch(contentUrl, {
+      method: "HEAD",
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+    }),
+  ]);
+
+  if (!headerResp.ok) {
+    throw translateUpstreamError(
+      headerResp,
+      await extractProblemDetail(headerResp),
+    );
+  }
+  if (!contentHead.ok) {
+    throw translateUpstreamError(
+      contentHead,
+      await extractProblemDetail(contentHead),
+    );
+  }
+
+  const headerBytes = new Uint8Array(await headerResp.arrayBuffer());
+  const contentLen = parseInt(
+    contentHead.headers.get("content-length") || "0",
+    10,
+  );
+  const plan = planEntry(
+    file.filePath,
+    headerBytes.byteLength + contentLen,
+    mtime,
+  );
+
+  return { file, headerBytes, contentLen, plan };
 }

--- a/frontend/src/app/api/datasets/[datasetId]/download.tar/route.ts
+++ b/frontend/src/app/api/datasets/[datasetId]/download.tar/route.ts
@@ -15,7 +15,12 @@ import {
   translateUpstreamError,
   buildContentDisposition,
 } from "@/app/lib/proxy";
-import { planEntry, TAR_BLOCK_SIZE, TAR_TRAILER_LEN, type PlannedEntry } from "@/app/lib/tar";
+import {
+  planEntry,
+  TAR_BLOCK_SIZE,
+  TAR_TRAILER_LEN,
+  type PlannedEntry,
+} from "@/app/lib/tar";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -113,7 +118,7 @@ export async function GET(
   // total TAR length so we can advertise Content-Length to the browser.
   let resolved: ResolvedEntry[];
   try {
-    resolved = await probeAll({files, token, publicKey, sdaBaseUrl, mtime});
+    resolved = await probeAll({ files, token, publicKey, sdaBaseUrl, mtime });
   } catch (e) {
     if (e instanceof Response) return e;
 
@@ -121,7 +126,8 @@ export async function GET(
     return errorResponse(502, `Could not reach the download backend: ${msg}`);
   }
 
-  const totalLen = resolved.reduce((sum, r) => sum + r.plan.entryLen, 0) + TAR_TRAILER_LEN;
+  const totalLen =
+    resolved.reduce((sum, r) => sum + r.plan.entryLen, 0) + TAR_TRAILER_LEN;
 
   async function* emitTar(): AsyncGenerator<Buffer> {
     for (const r of resolved) {

--- a/frontend/src/app/api/datasets/[datasetId]/download.tar/route.ts
+++ b/frontend/src/app/api/datasets/[datasetId]/download.tar/route.ts
@@ -21,12 +21,12 @@ import {
   TAR_TRAILER_LEN,
   type PlannedEntry,
 } from "@/app/lib/tar";
+import { MAX_TAR_SELECTION } from "@/app/lib/constants";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const HEADER_FETCH_CONCURRENCY = 32;
-const MAX_SELECTED_FILE_IDS = 1000;
 const TRAILER = new Uint8Array(TAR_TRAILER_LEN);
 
 type ResolvedEntry = {
@@ -63,10 +63,10 @@ export async function GET(
     if (ids.length === 0) {
       return errorResponse(400, "fileIds query parameter is empty.");
     }
-    if (ids.length > MAX_SELECTED_FILE_IDS) {
+    if (ids.length > MAX_TAR_SELECTION) {
       return errorResponse(
         400,
-        `Too many fileIds; maximum is ${MAX_SELECTED_FILE_IDS}.`,
+        `Too many fileIds; maximum is ${MAX_TAR_SELECTION}.`,
       );
     }
     selectedFileIds = new Set(ids);
@@ -106,6 +106,16 @@ export async function GET(
       selectedFileIds
         ? "No files match the requested fileIds."
         : "Dataset has no files to download.",
+    );
+  }
+
+  // Guard the whole-dataset path. The selection path is already capped by
+  // the fileIds check above; this catches a request with no fileIds against
+  // a dataset that happens to have more files than we can handle in one go.
+  if (files.length > MAX_TAR_SELECTION) {
+    return errorResponse(
+      400,
+      `Dataset has ${files.length} files; per-request TAR is capped at ${MAX_TAR_SELECTION}. Select a subset of files instead.`,
     );
   }
 

--- a/frontend/src/app/api/files/[fileId]/route.ts
+++ b/frontend/src/app/api/files/[fileId]/route.ts
@@ -1,54 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/app/lib/session";
 import { getConfig } from "@/app/lib/config";
-
-// Predictable JSON error response for the frontend, with no caching.
-function errorResponse(status: number, message: string) {
-  return NextResponse.json(
-    { error: message, status },
-    {
-      status,
-      headers: { "cache-control": "no-store" },
-    },
-  );
-}
-
-// Extract a human-readable message from an application/problem+json body.
-async function extractProblemDetail(
-  upstream: Response,
-): Promise<string | null> {
-  const contentType = upstream.headers.get("content-type") || "";
-  if (!contentType.includes("json")) return null;
-  try {
-    const problem = await upstream.json();
-    if (typeof problem?.detail === "string") return problem.detail;
-    if (typeof problem?.title === "string") return problem.title;
-  } catch {
-    // Ignore malformed body and fall back to a generic message.
-  }
-  return null;
-}
-
-function translateUpstreamError(
-  upstream: Response,
-  detail: string | null,
-): NextResponse {
-  const fallback =
-    upstream.status === 401
-      ? "Authentication with the download backend failed. Please sign in again."
-      : upstream.status === 403
-        ? "You do not have access to this file (or it does not exist)."
-        : upstream.status === 416
-          ? "The requested byte range is not satisfiable."
-          : `Download failed with status ${upstream.status}.`;
-  return errorResponse(upstream.status, detail || fallback);
-}
-
-function buildContentDisposition(filename: string): string {
-  // filename is assumed to be HTTP-header-safe
-  const encoded = encodeURIComponent(filename);
-  return `attachment; filename="${filename}"; filename*=UTF-8''${encoded}`;
-}
+import {
+  errorResponse,
+  extractProblemDetail,
+  translateUpstreamError,
+  buildContentDisposition,
+} from "@/app/lib/proxy";
 
 function getFallbackFilename(filePath: string | null, fileId: string): string {
   if (filePath) {

--- a/frontend/src/app/components/BatchDownloadActions.tsx
+++ b/frontend/src/app/components/BatchDownloadActions.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+type BatchDownloadActionsProps = {
+  selectedFileIds: Set<string>;
+  datasetId: string;
+  canDownload?: boolean;
+};
+
+const MAX_TAR_SELECTION = 1000;
+
+export function BatchDownloadActions({
+  selectedFileIds,
+  datasetId,
+  canDownload = true,
+}: BatchDownloadActionsProps) {
+  const selectedCount = selectedFileIds.size;
+  const tooMany = selectedCount > MAX_TAR_SELECTION;
+  const enabled = canDownload && selectedCount > 0 && !tooMany;
+
+  const tarUrl =
+    `/api/datasets/${encodeURIComponent(datasetId)}/download.tar` +
+    `?fileIds=${Array.from(selectedFileIds).map(encodeURIComponent).join(",")}`;
+
+  const reason = !canDownload
+    ? "Upload your Crypt4GH public key on the profile page to enable downloads."
+    : selectedCount === 0
+      ? "Select one or more files to enable TAR download."
+      : tooMany
+        ? `Too many files selected (${selectedCount}). The per-selection TAR is capped at ${MAX_TAR_SELECTION}; use “Download dataset” instead.`
+        : "";
+
+  return (
+    <div className="d-flex align-items-center gap-2">
+      {enabled ? (
+        <a
+          className="btn btn-outline-primary"
+          href={tarUrl}
+          download
+          rel="noopener"
+        >
+          Download selected as TAR
+        </a>
+      ) : (
+        <button
+          type="button"
+          className="btn btn-outline-primary"
+          disabled
+          title={reason}
+        >
+          Download selected as TAR
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/components/BatchDownloadActions.tsx
+++ b/frontend/src/app/components/BatchDownloadActions.tsx
@@ -1,12 +1,12 @@
 "use client";
 
+import { MAX_TAR_SELECTION } from "@/app/lib/constants";
+
 type BatchDownloadActionsProps = {
   selectedFileIds: Set<string>;
   datasetId: string;
   canDownload?: boolean;
 };
-
-const MAX_TAR_SELECTION = 1000;
 
 export function BatchDownloadActions({
   selectedFileIds,
@@ -24,13 +24,13 @@ export function BatchDownloadActions({
   const reason = !canDownload
     ? "Upload your Crypt4GH public key on the profile page to enable downloads."
     : selectedCount === 0
-      ? "Select one or more files to enable TAR download."
+      ? null // not really an error — don't nag the user
       : tooMany
-        ? `Too many files selected (${selectedCount}). The per-selection TAR is capped at ${MAX_TAR_SELECTION}; use “Download dataset” instead.`
-        : "";
+        ? `Selection exceeds the ${MAX_TAR_SELECTION}-file cap.`
+        : null;
 
   return (
-    <div className="d-flex align-items-center gap-2">
+    <div className="d-flex flex-column align-items-start gap-1">
       {enabled ? (
         <a
           className="btn btn-outline-primary"
@@ -45,10 +45,18 @@ export function BatchDownloadActions({
           type="button"
           className="btn btn-outline-primary"
           disabled
-          title={reason}
+          aria-describedby={reason ? "batch-tar-reason" : undefined}
         >
           Download selected as TAR
         </button>
+      )}
+      {reason && (
+        <small
+          id="batch-tar-reason"
+          className={`text-${tooMany ? "warning" : "muted"}`}
+        >
+          {reason}
+        </small>
       )}
     </div>
   );

--- a/frontend/src/app/components/DatasetFiles.tsx
+++ b/frontend/src/app/components/DatasetFiles.tsx
@@ -9,6 +9,7 @@ import { ClipboardValue } from "./ClipboardValue";
 import InfoTooltip from "./InfoTooltip";
 import { ItemSelector, useItemsPerPage } from "./ItemsPerPage";
 import { ChecksumExportActions } from "./ChecksumExportActions";
+import { BatchDownloadActions } from "./BatchDownloadActions";
 
 type DatasetFilesProps = {
   files: DatasetFile[];
@@ -201,6 +202,11 @@ export default function DatasetFiles({
           <strong>{selectedFileIds.size}</strong>{" "}
           {selectedFileIds.size === 1 ? "file selected" : "files selected"}
         </div>
+        <BatchDownloadActions
+          selectedFileIds={selectedFileIds}
+          datasetId={datasetId}
+          canDownload={canDownload}
+        />
         <ChecksumExportActions
           files={files}
           selectedFileIds={selectedFileIds}

--- a/frontend/src/app/lib/constants.ts
+++ b/frontend/src/app/lib/constants.ts
@@ -1,0 +1,4 @@
+// We currently cap the maximum number of files that can be requested in one TAR to
+// keep the request line limit <8KB and to avoid DoS risks. This can be relaxed in the
+// future if we implement a more robust request format (e.g. POST with JSON body).
+export const MAX_TAR_SELECTION = 200;

--- a/frontend/src/app/lib/proxy.ts
+++ b/frontend/src/app/lib/proxy.ts
@@ -1,0 +1,47 @@
+import "server-only";
+import { NextResponse } from "next/server";
+
+// Predictable JSON error response for the frontend, with no caching.
+export function errorResponse(status: number, message: string) {
+  return NextResponse.json(
+    { error: message, status },
+    { status, headers: { "cache-control": "no-store" } },
+  );
+}
+
+// Extract a human-readable message from an application/problem+json body.
+export async function extractProblemDetail(
+  upstream: Response,
+): Promise<string | null> {
+  const contentType = upstream.headers.get("content-type") || "";
+  if (!contentType.includes("json")) return null;
+  try {
+    const problem = await upstream.json();
+    if (typeof problem?.detail === "string") return problem.detail;
+    if (typeof problem?.title === "string") return problem.title;
+  } catch {
+    // Ignore malformed body and fall back to a generic message.
+  }
+  return null;
+}
+
+export function translateUpstreamError(
+  upstream: Response,
+  detail: string | null,
+): NextResponse {
+  const fallback =
+    upstream.status === 401
+      ? "Authentication with the download backend failed. Please sign in again."
+      : upstream.status === 403
+        ? "You do not have access to this file (or it does not exist)."
+        : upstream.status === 416
+          ? "The requested byte range is not satisfiable."
+          : `Download failed with status ${upstream.status}.`;
+  return errorResponse(upstream.status, detail || fallback);
+}
+
+export function buildContentDisposition(filename: string): string {
+  // filename is assumed to be HTTP-header-safe
+  const encoded = encodeURIComponent(filename);
+  return `attachment; filename="${filename}"; filename*=UTF-8''${encoded}`;
+}

--- a/frontend/src/app/lib/tar.test.ts
+++ b/frontend/src/app/lib/tar.test.ts
@@ -35,7 +35,9 @@ describe("planEntry", () => {
     const path = "dir/sub/file.bin";
     const p = planEntry(path, 1, 0);
     // Decode a window wider than the path so we can also see the trailing NUL.
-    const nameWindow = DECODER.decode(p.ustarBlock.subarray(0, path.length + 1));
+    const nameWindow = DECODER.decode(
+      p.ustarBlock.subarray(0, path.length + 1),
+    );
     expect(nameWindow.startsWith(`${path}\0`)).toBe(true);
     expect(DECODER.decode(p.ustarBlock.subarray(257, 263))).toBe("ustar\0");
     expect(p.ustarBlock[263]).toBe(0x30);
@@ -57,10 +59,7 @@ describe("planEntry", () => {
     for (let i = 0; i < TAR_BLOCK_SIZE; i++) {
       expected += i >= 148 && i < 156 ? 0x20 : p.ustarBlock[i];
     }
-    const stored = parseInt(
-      DECODER.decode(p.ustarBlock.subarray(148, 154)),
-      8,
-    );
+    const stored = parseInt(DECODER.decode(p.ustarBlock.subarray(148, 154)), 8);
     expect(stored).toBe(expected);
     expect(p.ustarBlock[154]).toBe(0);
     expect(p.ustarBlock[155]).toBe(0x20);
@@ -104,7 +103,9 @@ describe("planEntry", () => {
     const at = planEntry("a".repeat(100), 1, 0);
     expect(at.paxBlock).toBeNull();
     // The full 100-byte path fills the name field, no trailing NUL.
-    expect(DECODER.decode(at.ustarBlock.subarray(0, 100))).toBe("a".repeat(100));
+    expect(DECODER.decode(at.ustarBlock.subarray(0, 100))).toBe(
+      "a".repeat(100),
+    );
 
     const over = planEntry("a".repeat(101), 1, 0);
     expect(over.paxBlock).not.toBeNull();

--- a/frontend/src/app/lib/tar.test.ts
+++ b/frontend/src/app/lib/tar.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, test } from "vitest";
+import { planEntry, TAR_BLOCK_SIZE } from "./tar";
+
+const ENCODER = new TextEncoder();
+const DECODER = new TextDecoder();
+
+// Read a TAR octal field, stopping at the first NUL or space terminator.
+function readOctal(buf: Uint8Array, offset: number, len: number): number {
+  let end = offset + len;
+  for (let i = offset; i < offset + len; i++) {
+    if (buf[i] === 0 || buf[i] === 0x20) {
+      end = i;
+      break;
+    }
+  }
+  return parseInt(DECODER.decode(buf.subarray(offset, end)) || "0", 8);
+}
+
+describe("planEntry", () => {
+  test("short path, no PAX, layout adds up", () => {
+    const p = planEntry("hello.txt", 14, 0);
+    expect(p.paxBlock).toBeNull();
+    expect(p.ustarBlock.byteLength).toBe(TAR_BLOCK_SIZE);
+    expect(p.paddingLen).toBe(TAR_BLOCK_SIZE - 14);
+    expect(p.entryLen).toBe(TAR_BLOCK_SIZE + 14 + (TAR_BLOCK_SIZE - 14));
+  });
+
+  test("size exactly one block: zero padding", () => {
+    const p = planEntry("a.bin", TAR_BLOCK_SIZE, 0);
+    expect(p.paddingLen).toBe(0);
+    expect(p.entryLen).toBe(2 * TAR_BLOCK_SIZE);
+  });
+
+  test("USTAR name field, magic, version", () => {
+    const path = "dir/sub/file.bin";
+    const p = planEntry(path, 1, 0);
+    // Decode a window wider than the path so we can also see the trailing NUL.
+    const nameWindow = DECODER.decode(p.ustarBlock.subarray(0, path.length + 1));
+    expect(nameWindow.startsWith(`${path}\0`)).toBe(true);
+    expect(DECODER.decode(p.ustarBlock.subarray(257, 263))).toBe("ustar\0");
+    expect(p.ustarBlock[263]).toBe(0x30);
+    expect(p.ustarBlock[264]).toBe(0x30);
+  });
+
+  test("USTAR numeric fields", () => {
+    const p = planEntry("f.txt", 1234, 1700000000);
+    expect(readOctal(p.ustarBlock, 100, 8)).toBe(0o644);
+    expect(readOctal(p.ustarBlock, 108, 8)).toBe(0);
+    expect(readOctal(p.ustarBlock, 116, 8)).toBe(0);
+    expect(readOctal(p.ustarBlock, 124, 12)).toBe(1234);
+    expect(readOctal(p.ustarBlock, 136, 12)).toBe(1700000000);
+  });
+
+  test("USTAR checksum matches the POSIX rule", () => {
+    const p = planEntry("a.txt", 5, 1000);
+    let expected = 0;
+    for (let i = 0; i < TAR_BLOCK_SIZE; i++) {
+      expected += i >= 148 && i < 156 ? 0x20 : p.ustarBlock[i];
+    }
+    const stored = parseInt(
+      DECODER.decode(p.ustarBlock.subarray(148, 154)),
+      8,
+    );
+    expect(stored).toBe(expected);
+    expect(p.ustarBlock[154]).toBe(0);
+    expect(p.ustarBlock[155]).toBe(0x20);
+  });
+
+  test("long path emits a PAX path= record", () => {
+    const long = "a/".repeat(60) + "file.bin";
+    const p = planEntry(long, 10, 0);
+    expect(p.paxBlock).not.toBeNull();
+    expect(p.paxBlock!.byteLength % TAR_BLOCK_SIZE).toBe(0);
+    expect(String.fromCharCode(p.paxBlock![156])).toBe("x");
+    const body = DECODER.decode(p.paxBlock!.subarray(TAR_BLOCK_SIZE));
+    expect(body).toContain(`path=${long}`);
+    const m = body.match(/^(\d+) path=/);
+    expect(m).not.toBeNull();
+    const len = parseInt(m![1], 10);
+    expect(body.slice(0, len).endsWith("\n")).toBe(true);
+  });
+
+  test("size beyond USTAR limit emits PAX size= and zeros the ustar size", () => {
+    const big = 8 ** 11;
+    const p = planEntry("big.bin", big, 0);
+    expect(p.paxBlock).not.toBeNull();
+    const body = DECODER.decode(p.paxBlock!.subarray(TAR_BLOCK_SIZE));
+    expect(body).toContain(`size=${big}`);
+    expect(readOctal(p.ustarBlock, 124, 12)).toBe(0);
+  });
+
+  test("deterministic: same inputs → same bytes", () => {
+    const a = planEntry("dir/file.bin", 1234, 555);
+    const b = planEntry("dir/file.bin", 1234, 555);
+    expect(a.ustarBlock).toEqual(b.ustarBlock);
+    expect(a.entryLen).toBe(b.entryLen);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Boundary, edge, and regression tests
+  // ---------------------------------------------------------------------------
+
+  test("path of exactly 100 bytes stays in USTAR (no PAX); 101 triggers PAX", () => {
+    const at = planEntry("a".repeat(100), 1, 0);
+    expect(at.paxBlock).toBeNull();
+    // The full 100-byte path fills the name field, no trailing NUL.
+    expect(DECODER.decode(at.ustarBlock.subarray(0, 100))).toBe("a".repeat(100));
+
+    const over = planEntry("a".repeat(101), 1, 0);
+    expect(over.paxBlock).not.toBeNull();
+  });
+
+  test("size at MAX_USTAR_SIZE stays in USTAR; MAX_USTAR_SIZE + 1 triggers PAX size=", () => {
+    const MAX_USTAR_SIZE = 8 ** 11 - 1;
+    const at = planEntry("f", MAX_USTAR_SIZE, 0);
+    expect(at.paxBlock).toBeNull();
+    expect(readOctal(at.ustarBlock, 124, 12)).toBe(MAX_USTAR_SIZE);
+
+    const over = planEntry("f", MAX_USTAR_SIZE + 1, 0);
+    expect(over.paxBlock).not.toBeNull();
+    expect(readOctal(over.ustarBlock, 124, 12)).toBe(0);
+  });
+
+  test("entryLen with PAX = paxBlock + ustar + payload + padding", () => {
+    const path = "a/".repeat(60) + "file.bin";
+    const p = planEntry(path, 1000, 0);
+    expect(p.paxBlock).not.toBeNull();
+    expect(p.entryLen).toBe(
+      p.paxBlock!.length + TAR_BLOCK_SIZE + 1000 + p.paddingLen,
+    );
+  });
+
+  test("empty file: zero padding, single-block entry", () => {
+    const p = planEntry("empty.txt", 0, 0);
+    expect(p.paxBlock).toBeNull();
+    expect(p.paddingLen).toBe(0);
+    expect(p.entryLen).toBe(TAR_BLOCK_SIZE);
+  });
+
+  test("1-byte file: 511 padding, two-block entry", () => {
+    const p = planEntry("one.txt", 1, 0);
+    expect(p.paxBlock).toBeNull();
+    expect(p.paddingLen).toBe(511);
+    expect(p.entryLen).toBe(2 * TAR_BLOCK_SIZE);
+  });
+
+  test("UTF-8 path triggers PAX by byte length, not code-point count", () => {
+    // 50 × "é" = 100 UTF-8 bytes → still fits
+    const fits = planEntry("é".repeat(50), 1, 0);
+    expect(fits.paxBlock).toBeNull();
+
+    // 51 × "é" = 102 UTF-8 bytes → PAX required
+    const overflows = planEntry("é".repeat(51), 1, 0);
+    expect(overflows.paxBlock).not.toBeNull();
+    const body = DECODER.decode(overflows.paxBlock!.subarray(TAR_BLOCK_SIZE));
+    expect(body).toContain(`path=${"é".repeat(51)}`);
+  });
+
+  test("PAX record's self-referential length is correct at 3-digit lengths", () => {
+    // Path long enough that the encoded record is ≥ 100 bytes, forcing the
+    // length-of-length fixed point to converge on a 3-digit length.
+    const path = "a".repeat(150);
+    const p = planEntry(path, 1, 0);
+    const body = DECODER.decode(p.paxBlock!.subarray(TAR_BLOCK_SIZE));
+    const m = body.match(/^(\d+) path=[^\n]*\n/);
+    expect(m).not.toBeNull();
+    const declaredLen = parseInt(m![1], 10);
+    const actualLen = ENCODER.encode(m![0]).length;
+    expect(declaredLen).toBe(actualLen);
+    expect(String(declaredLen).length).toBeGreaterThanOrEqual(3);
+  });
+
+  test("checksum changes when path or mtime changes", () => {
+    const a = planEntry("a.txt", 100, 1000);
+    const b = planEntry("a.txt", 100, 2000);
+    const c = planEntry("b.txt", 100, 1000);
+
+    const csA = DECODER.decode(a.ustarBlock.subarray(148, 154));
+    const csB = DECODER.decode(b.ustarBlock.subarray(148, 154));
+    const csC = DECODER.decode(c.ustarBlock.subarray(148, 154));
+
+    expect(csA).not.toBe(csB); // mtime affects checksum
+    expect(csA).not.toBe(csC); // name affects checksum
+  });
+
+  test("both long path AND large size produce one PAX block with both records", () => {
+    const path = "a/".repeat(60) + "file.bin";
+    const big = 8 ** 11;
+    const p = planEntry(path, big, 0);
+    expect(p.paxBlock).not.toBeNull();
+
+    const body = DECODER.decode(p.paxBlock!.subarray(TAR_BLOCK_SIZE));
+    expect(body).toContain(`path=${path}`);
+    expect(body).toContain(`size=${big}`);
+
+    // The ustar block reflects PAX overrides for both fields.
+    expect(readOctal(p.ustarBlock, 124, 12)).toBe(0);
+    const ustarName = DECODER.decode(p.ustarBlock.subarray(0, 100)).replace(
+      /\0+$/,
+      "",
+    );
+    expect(path.endsWith(ustarName)).toBe(true);
+  });
+
+  test("ustar name is the last 100 bytes of an overlong path", () => {
+    const path = "a".repeat(200) + "/end.bin";
+    const p = planEntry(path, 1, 0);
+    const ustarName = DECODER.decode(p.ustarBlock.subarray(0, 100));
+    const expectedTail = path.slice(path.length - 100);
+    expect(ustarName.startsWith(expectedTail)).toBe(true);
+    expect(ustarName.endsWith("end.bin")).toBe(true);
+  });
+
+  test("PAX block name uses the PaxHeaders/<basename> convention", () => {
+    const longPath = "a/".repeat(60) + "sample.bam.c4gh";
+    const p = planEntry(longPath, 1, 0);
+    const name = DECODER.decode(p.paxBlock!.subarray(0, 100)).replace(
+      /\0+$/,
+      "",
+    );
+    expect(name).toContain("PaxHeaders/");
+    expect(name.endsWith("sample.bam.c4gh")).toBe(true);
+  });
+});

--- a/frontend/src/app/lib/tar.ts
+++ b/frontend/src/app/lib/tar.ts
@@ -1,0 +1,214 @@
+/*
+ * Deterministic TAR encoder (POSIX USTAR + PAX). We do not use any
+ * existing TAR libraries because we need full control over the framing
+ * of each entry in the archive, to support HTTP Range resumes on the
+ * download endpoint.
+ *
+ * Each file becomes a regular USTAR entry. Paths longer than 100 bytes
+ * or sizes above 8 GiB get a PAX extended header in front carrying the
+ * full path/size, since they don't fit in USTAR's fixed-width fields.
+ * Directories aren't emitted explicitly — tar readers reconstruct them
+ * from the file paths.
+ *
+ * The encoder is deterministic by design: given the same inputs
+ * (path, size, mtime), the framing bytes around the payload — the PAX
+ * header, the USTAR header, and the trailing padding — are always
+ * identical, and the entry occupies a fixed number of bytes in the
+ * archive. The payload bytes themselves are streamed in by the caller
+ * and are not produced by this module.
+ *
+ * This stable framing is what later lets the server support HTTP Range
+ * resumes: the layout of each entry within the archive is fully
+ * predictable from metadata alone, so the same byte offsets always
+ * refer to the same region (PAX header / USTAR header / payload /
+ * padding) across requests.
+ */
+
+// TAR is a stream of fixed-size 512-byte blocks.
+export const TAR_BLOCK_SIZE = 512;
+
+// An archive ends with two consecutive all-zero blocks ("the trailer").
+export const TAR_TRAILER_LEN = 2 * TAR_BLOCK_SIZE;
+
+// USTAR's `name` field is only 100 bytes wide. Longer paths must use PAX.
+const NAME_LIMIT = 100;
+
+// USTAR's `size`. Files larger than this need a PAX `size=` record instead.
+const MAX_USTAR_SIZE = 8 ** 11 - 1;
+
+const ENCODER = new TextEncoder();
+
+// Write a string into `buf` at `offset`, truncating to `max` bytes.
+// We rely on the buffer being zero-initialised for NUL termination.
+function writeAscii(
+  buf: Uint8Array,
+  offset: number,
+  max: number,
+  value: string,
+) {
+  const bytes = ENCODER.encode(value);
+  buf.set(bytes.subarray(0, Math.min(bytes.length, max)), offset);
+}
+
+// Write a TAR octal field: (fieldLen - 1) ASCII octal digits, zero-padded
+// on the left, followed by a single NUL byte. This is the format every
+// numeric field in a USTAR header uses (mode, uid, size, mtime, …).
+function writeOctal(
+  buf: Uint8Array,
+  offset: number,
+  fieldLen: number,
+  value: number,
+) {
+  const digits = fieldLen - 1;
+  const s = value.toString(8).padStart(digits, "0");
+  buf.set(ENCODER.encode(s), offset);
+  buf[offset + digits] = 0;
+}
+
+// Build a single 512-byte USTAR header block. Used both for regular file
+// entries (typeflag "0") and for PAX extended-header blocks (typeflag "x").
+// Most fields are hard-coded (mode 0644, uid/gid 0, empty uname/gname) so
+// the bytes are deterministic and we don't emit host information.
+function buildUstarHeader(opts: {
+  name: string;
+  ustarSize: number;
+  mtime: number;
+  typeflag: "0" | "x";
+}): Uint8Array {
+  const buf = new Uint8Array(TAR_BLOCK_SIZE);
+  writeAscii(buf, 0, 100, opts.name);
+  writeOctal(buf, 100, 8, 0o644);
+  writeOctal(buf, 108, 8, 0);
+  writeOctal(buf, 116, 8, 0);
+  writeOctal(buf, 124, 12, opts.ustarSize);
+  writeOctal(buf, 136, 12, opts.mtime);
+
+  // The checksum is computed over the whole block with the chksum field
+  // itself treated as 8 spaces. We fill those spaces in first, then sum,
+  // then overwrite with the real value.
+  buf.fill(0x20, 148, 156);
+  buf[156] = opts.typeflag.charCodeAt(0);
+  buf.set(ENCODER.encode("ustar"), 257);
+  buf[262] = 0;
+  buf[263] = 0x30;
+  buf[264] = 0x30;
+
+  let sum = 0;
+  for (let i = 0; i < TAR_BLOCK_SIZE; i++) sum += buf[i];
+
+  // The `chksum` field has a quirky format: 6 octal digits, NUL, space.
+  buf.set(ENCODER.encode(sum.toString(8).padStart(6, "0")), 148);
+  buf[154] = 0;
+  buf[155] = 0x20;
+  return buf;
+}
+
+// Format a single PAX record: "<len> <key>=<value>\n", where <len> is the
+// total byte length of the record *including the digits of <len> itself*.
+// That self-reference means we have to solve a small fixed point; in
+// practice it converges in at most two iterations.
+function paxRecord(key: string, value: string): string {
+  const suffix = ` ${key}=${value}\n`;
+  const suffixLen = ENCODER.encode(suffix).length;
+  let len = suffixLen + 1;
+  for (;;) {
+    const total = String(len).length + suffixLen;
+    if (total === len) return String(len) + suffix;
+    len = total;
+  }
+}
+
+// Pad a buffer up to the next 512-byte boundary with zeros. Used for the
+// PAX payload so that the next entry's header lands on a block boundary.
+function padToBlock(bytes: Uint8Array): Uint8Array {
+  const rem = bytes.length % TAR_BLOCK_SIZE;
+  if (rem === 0) return bytes;
+  const out = new Uint8Array(bytes.length + (TAR_BLOCK_SIZE - rem));
+  out.set(bytes);
+  return out;
+}
+
+// When a path is too long for USTAR's 100-byte `name` field, we still need
+// to put *something* there as a fallback. The trailing 100 bytes are the
+// most informative slice (they usually contain the filename itself).
+// PAX-aware readers ignore this and use the PAX `path=` record instead.
+function tailNameForUstar(filePath: string): string {
+  const bytes = ENCODER.encode(filePath);
+  if (bytes.length <= NAME_LIMIT) return filePath;
+  return new TextDecoder("utf-8", { fatal: false }).decode(
+    bytes.subarray(bytes.length - NAME_LIMIT),
+  );
+}
+
+// The PAX header block itself needs a `name` field too. Convention (used
+// by GNU tar) is "PaxHeaders/<basename>" — innocuous if a non-PAX-aware
+// reader extracts it by mistake.
+function paxSyntheticName(filePath: string): string {
+  const basename = filePath.split("/").pop() || "file";
+  return tailNameForUstar(`PaxHeaders/${basename}`);
+}
+
+// Describes the byte layout of one TAR entry without holding the file's
+// payload. The route handler uses this to know exactly what to emit
+// before and after the streamed file bytes, and how many bytes the whole
+// entry will occupy.
+export type PlannedEntry = {
+  filePath: string;
+  fileDataLen: number;
+  paxBlock: Uint8Array | null; // null when no PAX extensions are needed
+  ustarBlock: Uint8Array; // always 512 bytes
+  paddingLen: number; // zero bytes to emit after the payload
+  entryLen: number; // total bytes occupied by this entry
+};
+
+// Plan a single TAR entry for a file. Decides whether PAX is needed for
+// long paths or large sizes, builds the framing blocks, and reports how
+// many bytes of padding the caller will need to emit after the payload.
+export function planEntry(
+  filePath: string,
+  fileDataLen: number,
+  mtime: number,
+): PlannedEntry {
+  const pathBytes = ENCODER.encode(filePath);
+  const needsPaxForPath = pathBytes.length > NAME_LIMIT;
+  const needsPaxForSize = fileDataLen > MAX_USTAR_SIZE;
+
+  // Emit a PAX block in front of the regular entry when either the path
+  // or the size doesn't fit in the USTAR fields.
+  let paxBlock: Uint8Array | null = null;
+  if (needsPaxForPath || needsPaxForSize) {
+    let body = "";
+    if (needsPaxForPath) body += paxRecord("path", filePath);
+    if (needsPaxForSize) body += paxRecord("size", String(fileDataLen));
+    const bodyBytes = ENCODER.encode(body);
+    const paxHeader = buildUstarHeader({
+      name: paxSyntheticName(filePath),
+      ustarSize: bodyBytes.length,
+      mtime,
+      typeflag: "x",
+    });
+    const paddedBody = padToBlock(bodyBytes);
+    paxBlock = new Uint8Array(paxHeader.length + paddedBody.length);
+    paxBlock.set(paxHeader, 0);
+    paxBlock.set(paddedBody, paxHeader.length);
+  }
+
+  // The regular file entry. If we already emitted a PAX `size=` record,
+  // zero out the USTAR `size` field — the PAX value is authoritative and
+  // the real size would overflow the 12-byte field anyway.
+  const ustarBlock = buildUstarHeader({
+    name: needsPaxForPath ? tailNameForUstar(filePath) : filePath,
+    ustarSize: needsPaxForSize ? 0 : fileDataLen,
+    mtime,
+    typeflag: "0",
+  });
+
+  // File payloads must be padded up to a 512-byte boundary. The double
+  // `% TAR_BLOCK_SIZE` turns "already on a boundary" into 0 instead of 512.
+  const paddingLen =
+    (TAR_BLOCK_SIZE - (fileDataLen % TAR_BLOCK_SIZE)) % TAR_BLOCK_SIZE;
+  const entryLen =
+    (paxBlock?.length ?? 0) + TAR_BLOCK_SIZE + fileDataLen + paddingLen;
+
+  return { filePath, fileDataLen, paxBlock, ustarBlock, paddingLen, entryLen };
+}

--- a/sdad-config.json.example
+++ b/sdad-config.json.example
@@ -5,6 +5,6 @@
     "nextAuthUrl": "http://localhost:3002",
     "oidcClientSecretPath": "/run/secrets/frontend-oidc-client-secret",
     "oidcClientIdPath": "/run/secrets/frontend-oidc-client-id",
-    "oidcRoot": "http://host.docker.internal:8800/oidc"
+    "oidcRoot": "http://host.docker.internal:8800/oidc",
     "allowHttp": true
 }


### PR DESCRIPTION
## Related issue(s) and PR(s)

This PR closes #116.

Adds a new `GET /api/datasets/{datasetId}/download.tar` endpoint that streams
a deterministic POSIX TAR (USTAR + PAX) built from a selection of files in
a dataset, and wires it up to a "Download selected as TAR" button in the
files table. The browser sees a single download with native progress.

Here comes a rather lengthy description of how it works.

### How it works

1. **Selection.** The user picks files in the dataset's file table; the new `BatchDownloadActions` component renders the link with a `?fileIds=id1,id2,...` query string. The button is disabled (with an inline explanation) when the selection is empty,  too large, or the user has no Crypt4GH public key configured.

2. **Prepare phase (parallel).** Server-side, the route fans out one  `GET /files/{id}/header` + one `HEAD /files/{id}/content` per file with bounded concurrency (32-wide). This gives us, per file, the recipient-specific re-encrypted Crypt4GH header bytes and the encrypted content size.

3. **Layout.** Files are sorted deterministically by path. Each entry is planned via  `planEntry()` in `app/lib/tar.ts` according to tar format standards.  This includes  PAX block (only if path > 100 bytes or size > 8 GiB), USTAR block, payload size, padding. Summing entry sizes plus the trailer padding gives the total `Content-Length` deterministically.

4. **Streaming.** An `async function*` emits the framing blocks, splices in the cached header bytes, then pipes `GET /content` straight through, then pads to a 512-byte boundary. `Readable.from(...)` gives end-to-end backpressure: if the browser slows down, the upstream content fetch slows down too. The stream is torn down on mismatch between advertised and actual `/content` length.

5. **Cancellation.** `request.signal` is plumbed through every upstream fetch so a client disconnect aborts the in-flight backend work.

### Why this shape

 **`Content-Length` up front.** 
- browser can show real progress, ETA
- Sets up the base for the follow-up PR that adds `Range`/`If-Range`/`ETag` support so a paused TAR download can resume
  natively.
- **In-house TAR encoder.** Node libraries don't expose the per-entry framing we need in order to compute byte offsets for resume support. 

### Limits

A new `MAX_TAR_SELECTION = 200` lives in `app/lib/constants.ts` and is the single source of truth for both the UI ("Download selected as TAR" button) and the API (returns 400 when exceeded. 
- 200 was picked because 200 UUID-sized file IDs in the query string is ~7.5 KB<8 KB, the later being the default request-line limit of e.g. nginx.
- we could in principle pass the `fileIDs` as non url parameters and then increase this number, the only limit now being the preparation phase taking minutes for huge datasets.

### Tests

- `app/lib/tar.test.ts`: pure unit tests for the TAR encoder including producing deterministic tar.
- `app/api/datasets/[datasetId]/download.tar/route.test.ts`: end-to-end tests on the route..

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Instructions on how to test

- Upload a pub key, select multiple files in a dataset, click `Download selected as TAR` and observe the browser take over.
- Untar the file (right-click -> extract here or e.g. `mkdir EGAD00000000001 && tar x -f EGAD00000000001.tar -C "EGAD00000000001"`
- decryot files
```
cd EGAD00000000001
sda-cli decrypt -key <private-c4gh-key-file> *.c4gh --clean
```
- Download checksums file and clean up the `.c4gh` extensions
```
sed -i 's/\.c4gh//g' EGAD00000000001-selected-files.sha256
or in MAC:
sed -i '' 's/\.c4gh//g' EGAD00000000001-selected-files.sha256
```
- Finally, check files integrity
```
cat EGAD00000000001-selected-files.sha256 | sha256sum --check
```

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any
- [x] All Acceptance Criteria (AC) Fulfilled and checked in the Related issue

- [ ] **Follow-up Backlog Items Created (if applicable):**
- opened #124 if we ever want to increase the number of allowed files to download beyond `200`.
