### PR TITLE
Resume batch file tar download

### DIFF
--- a/frontend/src/app/api/datasets/[datasetId]/download.tar/route.test.ts
+++ b/frontend/src/app/api/datasets/[datasetId]/download.tar/route.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi, beforeEach, afterEach } from "vitest";
-import { GET } from "./route";
+import { GET, HEAD } from "./route";
 import { NextRequest } from "next/server";
 import type { SessionData } from "@/app/lib/SessionManager";
 import { MAX_TAR_SELECTION } from "@/app/lib/constants";
@@ -11,8 +11,11 @@ vi.mock(import("next/server"), async (importOriginal) => {
   return { ...actual, connection: async () => {} };
 });
 vi.mock(import("server-only"), () => ({}));
-vi.mock(import("@/app/lib/config"), () => ({
-  getConfig: async () => ({ sdaBaseUrl, sessionSecretPath: "" }),
+vi.mock("@/app/lib/config", () => ({
+  getConfig: async () => ({
+    sdaBaseUrl,
+    sessionSecretPath: "",
+  }),
 }));
 
 const sessionState: { current: SessionData | null } = { current: null };
@@ -95,7 +98,33 @@ const F2_CONTENT = new Uint8Array(20).map((_, i) => 50 + i);
 const TRAILER_START = 2048;
 const TOTAL = 3072;
 
-function defaultUpstream(url: string, method: string): Response {
+async function readChunks(stream: ReadableStream<Uint8Array> | null) {
+  if (!stream) return [];
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) chunks.push(value);
+  }
+  return chunks;
+}
+
+function defaultUpstream(
+  url: string,
+  method: string,
+  range: string | null = null,
+): Response {
+  function rangeSlice(buf: Uint8Array) {
+    if (!range) return new Response(new Uint8Array(buf), { status: 200 });
+    const m = range.match(/^bytes=(\d+)-(\d+)$/);
+    if (!m) return new Response("bad range", { status: 400 });
+    const s = parseInt(m[1], 10);
+    const e = parseInt(m[2], 10);
+    return new Response(new Uint8Array(buf.subarray(s, e + 1)), {
+      status: 206,
+    });
+  }
   if (url.endsWith("/files/f1/header") && method === "GET")
     return new Response(F1_HEADER, {
       status: 200,
@@ -117,9 +146,9 @@ function defaultUpstream(url: string, method: string): Response {
       headers: { "content-length": String(F2_CONTENT.length) },
     });
   if (url.endsWith("/files/f1/content") && method === "GET")
-    return new Response(F1_CONTENT, { status: 200 });
+    return rangeSlice(F1_CONTENT);
   if (url.endsWith("/files/f2/content") && method === "GET")
-    return new Response(F2_CONTENT, { status: 200 });
+    return rangeSlice(F2_CONTENT);
   return new Response("unmocked " + url, { status: 500 });
 }
 
@@ -132,7 +161,8 @@ function installDefaultFetch() {
           ? input.toString()
           : (input as Request).url;
     const method = (init?.method || "GET").toUpperCase();
-    return Promise.resolve(defaultUpstream(url, method));
+    const range = new Headers(init?.headers).get("range");
+    return Promise.resolve(defaultUpstream(url, method, range));
   });
 }
 
@@ -615,5 +645,335 @@ describe("GET /api/datasets/[datasetId]/download.tar", () => {
       expect(s).toBeInstanceOf(AbortSignal);
       expect(s.aborted).toBe(true);
     }
+  });
+
+  // new ETag behavior for resume support
+  test("returns an ETag bound to the recipient key", async () => {
+    sessionState.current = validSession;
+    installDefaultFetch();
+    const { req, params } = makeReq();
+    const resp = await GET(req, { params });
+    expect(resp.headers.get("etag")).toMatch(/^".+"$/);
+    expect(resp.headers.get("accept-ranges")).toBe("bytes");
+  });
+
+  test("ETag is stable across preflights for the same recipient + selection", async () => {
+    sessionState.current = validSession;
+    installDefaultFetch();
+    const r1 = await GET(makeReq().req, { params: makeReq().params });
+    const r2 = await GET(makeReq().req, { params: makeReq().params });
+    expect(r1.headers.get("etag")).toBe(r2.headers.get("etag"));
+  });
+
+  test("ETag changes when the recipient public key changes", async () => {
+    sessionState.current = validSession;
+    installDefaultFetch();
+    const r1 = await GET(makeReq().req, { params: makeReq().params });
+    sessionState.current = {
+      token: "tok",
+      publicKey: { key: "OTHER", pemChecksum: "different-pem" },
+    };
+    const r2 = await GET(makeReq().req, { params: makeReq().params });
+    expect(r1.headers.get("etag")).not.toBe(r2.headers.get("etag"));
+  });
+
+  // HEAD and Range tests for resume support
+  test("HEAD returns total size and tar headers, no body", async () => {
+    sessionState.current = validSession;
+    installDefaultFetch();
+    const url = new URL("http://localhost/api/datasets/ds1/download.tar");
+    const resp = await HEAD(new NextRequest(url), {
+      params: Promise.resolve({ datasetId: "ds1" }),
+    });
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("content-length")).toBe(String(TOTAL));
+    expect(resp.headers.get("accept-ranges")).toBe("bytes");
+    expect(resp.headers.get("etag")).toMatch(/^".+"$/);
+    expect(resp.headers.get("content-type")).toBe("application/x-tar");
+    expect((await readAll(resp.body)).byteLength).toBe(0);
+  });
+
+  test("Range strictly inside f2 content returns 206 with translated bytes", async () => {
+    sessionState.current = validSession;
+    installDefaultFetch();
+    const start = 1541 + 5;
+    const end = 1541 + 9;
+    const url = new URL("http://localhost/api/datasets/ds1/download.tar");
+    const req = new NextRequest(url, {
+      headers: { range: `bytes=${start}-${end}` },
+    });
+    const resp = await GET(req, {
+      params: Promise.resolve({ datasetId: "ds1" }),
+    });
+    expect(resp.status).toBe(206);
+    expect(resp.headers.get("content-range")).toBe(
+      `bytes ${start}-${end}/${TOTAL}`,
+    );
+    expect(await readAll(resp.body)).toEqual(F2_CONTENT.subarray(5, 10));
+  });
+
+  test("Range spanning f1 padding + f2 ustar header stitches static regions", async () => {
+    sessionState.current = validSession;
+    installDefaultFetch();
+    const url = new URL("http://localhost/api/datasets/ds1/download.tar");
+    const req = new NextRequest(url, { headers: { range: "bytes=1021-1027" } });
+    const resp = await GET(req, {
+      params: Promise.resolve({ datasetId: "ds1" }),
+    });
+    expect(resp.status).toBe(206);
+    const body = await readAll(resp.body);
+    expect(body.byteLength).toBe(7);
+    expect(body.subarray(0, 3)).toEqual(new Uint8Array(3));
+    expect(new TextDecoder().decode(body.subarray(3))).toBe("b/sa");
+  });
+
+  test("Open-ended range starting in the trailer returns trailer zeros", async () => {
+    sessionState.current = validSession;
+    installDefaultFetch();
+    const url = new URL("http://localhost/api/datasets/ds1/download.tar");
+    const req = new NextRequest(url, { headers: { range: "bytes=2048-" } });
+    const resp = await GET(req, {
+      params: Promise.resolve({ datasetId: "ds1" }),
+    });
+    expect(resp.status).toBe(206);
+    expect(await readAll(resp.body)).toEqual(new Uint8Array(1024));
+  });
+
+  test("Range past end → 416 with Content-Range total", async () => {
+    sessionState.current = validSession;
+    installDefaultFetch();
+    const url = new URL("http://localhost/api/datasets/ds1/download.tar");
+    const req = new NextRequest(url, {
+      headers: { range: `bytes=${TOTAL + 10}-` },
+    });
+    const resp = await GET(req, {
+      params: Promise.resolve({ datasetId: "ds1" }),
+    });
+    expect(resp.status).toBe(416);
+    expect(resp.headers.get("content-range")).toBe(`bytes */${TOTAL}`);
+  });
+
+  test("If-Range mismatch → ignore Range, return 200 full archive", async () => {
+    sessionState.current = validSession;
+    installDefaultFetch();
+    const url = new URL("http://localhost/api/datasets/ds1/download.tar");
+    const req = new NextRequest(url, {
+      headers: { range: "bytes=1024-1123", "if-range": '"stale-tar-etag"' },
+    });
+    const resp = await GET(req, {
+      params: Promise.resolve({ datasetId: "ds1" }),
+    });
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("content-length")).toBe(String(TOTAL));
+    expect(resp.headers.get("content-range")).toBeNull();
+  });
+
+  // Refuse ranges that start in the middle of a c4gh header
+  test("Range whose start lands inside entry 1's c4gh header → 200 full archive", async () => {
+    sessionState.current = validSession;
+    installDefaultFetch();
+    const url = new URL("http://localhost/api/datasets/ds1/download.tar");
+    const req = new NextRequest(url, { headers: { range: "bytes=513-700" } });
+    const resp = await GET(req, {
+      params: Promise.resolve({ datasetId: "ds1" }),
+    });
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("content-range")).toBeNull();
+    expect((await readAll(resp.body)).byteLength).toBe(TOTAL);
+  });
+
+  test("Range starting at the first byte of content (just past a c4gh header) → 206", async () => {
+    sessionState.current = validSession;
+    installDefaultFetch();
+    const url = new URL("http://localhost/api/datasets/ds1/download.tar");
+    const req = new NextRequest(url, { headers: { range: "bytes=1541-1560" } });
+    const resp = await GET(req, {
+      params: Promise.resolve({ datasetId: "ds1" }),
+    });
+    expect(resp.status).toBe(206);
+    expect(resp.headers.get("content-range")).toBe(`bytes 1541-1560/${TOTAL}`);
+    expect(await readAll(resp.body)).toEqual(F2_CONTENT);
+  });
+
+  // Always emit a c4gh header together with the following bytes, never terminate a chunk on header bytes alone.
+  test("emits each c4gh header together with following bytes (atomic)", async () => {
+    sessionState.current = validSession;
+    installDefaultFetch();
+    const { req, params } = makeReq();
+    const resp = await GET(req, { params });
+    const chunks = await readChunks(resp.body);
+
+    // Walk chunks and compute their absolute [start, end) ranges.
+    type Span = { start: number; end: number };
+    const spans: Span[] = [];
+    let offset = 0;
+    for (const c of chunks) {
+      spans.push({ start: offset, end: offset + c.byteLength });
+      offset += c.byteLength;
+    }
+
+    function chunkContaining(byte: number): Span {
+      const span = spans.find((s) => s.start <= byte && byte < s.end);
+      if (!span) throw new Error(`No chunk contains byte ${byte}`);
+      return span;
+    }
+
+    // Property: any chunk containing a c4gh-header byte must also contain
+    // the first byte of the following region. The body covers two c4gh
+    // header regions, each followed by a content region.
+    const c4ghHeaders = [
+      { start: 512, end: 516, firstByteAfter: 516 }, // f1: 4 bytes header, then content
+      { start: 1536, end: 1541, firstByteAfter: 1541 }, // f2: 5 bytes header, then content
+    ];
+
+    for (const h of c4ghHeaders) {
+      for (let b = h.start; b < h.end; b++) {
+        const span = chunkContaining(b);
+        expect(span.end).toBeGreaterThan(h.firstByteAfter);
+      }
+    }
+  });
+
+  // Good to have tests.
+
+  // Scenario where backend API misbehaves. But we can only defend against backend API
+  // returning more bytes than asked for, not fewer.
+  test("clamps upstream content when upstream returns more bytes than asked for", async () => {
+    sessionState.current = validSession;
+
+    // Override the default mock: upstream honours the Range's start position
+    // but returns trailing bytes beyond the requested end.
+    vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : (input as Request).url;
+      const method = (init?.method || "GET").toUpperCase();
+      const range = new Headers(init?.headers).get("range");
+
+      if (url.endsWith("/files/f2/content") && method === "GET" && range) {
+        const m = range.match(/^bytes=(\d+)-(\d+)$/);
+        if (m) {
+          const s = parseInt(m[1], 10);
+          // Return from `s` to the end of the content body, regardless of the
+          // requested end. This simulates an upstream that honours the start
+          // of the range but doesn't bother trimming the tail.
+          return Promise.resolve(
+            new Response(new Uint8Array(F2_CONTENT.subarray(s)), {
+              status: 206,
+              headers: {
+                "content-length": String(F2_CONTENT.length - s),
+                "content-range": `bytes ${s}-${F2_CONTENT.length - 1}/${F2_CONTENT.length}`,
+              },
+            }),
+          );
+        }
+      }
+      return Promise.resolve(defaultUpstream(url, method, range));
+    });
+
+    // Ask for a 5-byte slice strictly inside f2 content.
+    const start = 1541 + 5;
+    const end = 1541 + 9;
+    const url = new URL("http://localhost/api/datasets/ds1/download.tar");
+    const req = new NextRequest(url, {
+      headers: { range: `bytes=${start}-${end}` },
+    });
+    const resp = await GET(req, {
+      params: Promise.resolve({ datasetId: "ds1" }),
+    });
+
+    expect(resp.status).toBe(206);
+    expect(resp.headers.get("content-length")).toBe("5");
+    expect(resp.headers.get("content-range")).toBe(
+      `bytes ${start}-${end}/${TOTAL}`,
+    );
+
+    const body = await readAll(resp.body);
+    // The 5 bytes the client asked for.
+    expect(body).toEqual(F2_CONTENT.subarray(5, 10));
+    expect(body.byteLength).toBe(5);
+  });
+
+  test("Range ending inside a c4gh header flushes pending at end-of-loop", async () => {
+    sessionState.current = validSession;
+    installDefaultFetch();
+    // bytes=511-515: 1 byte from the tail of f1's ustar block + 4 bytes of
+    // f1's c4gh-header. The header bytes go into `pending` and the loop exits
+    // at pos=516 with no further region to coalesce with. The final
+    // `if (pending) yield pending;` is what delivers them.
+    const url = new URL("http://localhost/api/datasets/ds1/download.tar");
+    const req = new NextRequest(url, { headers: { range: "bytes=511-515" } });
+    const resp = await GET(req, {
+      params: Promise.resolve({ datasetId: "ds1" }),
+    });
+    expect(resp.status).toBe(206);
+    expect(resp.headers.get("content-length")).toBe("5");
+    expect(resp.headers.get("content-range")).toBe(`bytes 511-515/${TOTAL}`);
+
+    const body = await readAll(resp.body);
+    expect(body.byteLength).toBe(5);
+    // First byte: ustar tail (zero-padded field).
+    expect(body[0]).toBe(0);
+    // Remaining 4 bytes: f1's c4gh-header verbatim.
+    expect(body.subarray(1)).toEqual(F1_HEADER);
+  });
+
+  test("HEAD with Range returns 206 + Content-Range, no body", async () => {
+    sessionState.current = validSession;
+    installDefaultFetch();
+    const url = new URL("http://localhost/api/datasets/ds1/download.tar");
+    const start = 1541 + 5;
+    const end = 1541 + 9;
+    const resp = await HEAD(
+      new NextRequest(url, { headers: { range: `bytes=${start}-${end}` } }),
+      { params: Promise.resolve({ datasetId: "ds1" }) },
+    );
+    expect(resp.status).toBe(206);
+    expect(resp.headers.get("content-length")).toBe("5");
+    expect(resp.headers.get("content-range")).toBe(
+      `bytes ${start}-${end}/${TOTAL}`,
+    );
+    expect(resp.headers.get("etag")).toMatch(/^".+"$/);
+    expect(resp.headers.get("accept-ranges")).toBe("bytes");
+    // No body — same Content-Length but zero bytes delivered.
+    expect((await readAll(resp.body)).byteLength).toBe(0);
+  });
+
+  test("HEAD with unsatisfiable Range returns 416", async () => {
+    sessionState.current = validSession;
+    installDefaultFetch();
+    const url = new URL("http://localhost/api/datasets/ds1/download.tar");
+    const resp = await HEAD(
+      new NextRequest(url, { headers: { range: `bytes=${TOTAL + 10}-` } }),
+      { params: Promise.resolve({ datasetId: "ds1" }) },
+    );
+    expect(resp.status).toBe(416);
+    expect(resp.headers.get("content-range")).toBe(`bytes */${TOTAL}`);
+  });
+
+  test("If-Range with a weak validator falls back to 200 even if the body matches", async () => {
+    sessionState.current = validSession;
+    installDefaultFetch();
+    // Get the current strong ETag.
+    const r0 = await GET(makeReq().req, { params: makeReq().params });
+    const strongEtag = r0.headers.get("etag")!;
+    await readAll(r0.body);
+
+    // Replay the same ETag value but as a weak validator.
+    const weakEtag = `W/${strongEtag}`;
+    const url = new URL("http://localhost/api/datasets/ds1/download.tar");
+    const req = new NextRequest(url, {
+      headers: { range: "bytes=1541-1560", "if-range": weakEtag },
+    });
+    const resp = await GET(req, {
+      params: Promise.resolve({ datasetId: "ds1" }),
+    });
+    // Weak validator: per spec, refuse the Range. Fall back to a full 200.
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("content-length")).toBe(String(TOTAL));
+    expect(resp.headers.get("content-range")).toBeNull();
   });
 });

--- a/frontend/src/app/api/datasets/[datasetId]/download.tar/route.ts
+++ b/frontend/src/app/api/datasets/[datasetId]/download.tar/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { Readable } from "node:stream";
+import * as crypto from "crypto";
 import { getSession } from "@/app/lib/session";
 import { getConfig } from "@/app/lib/config";
 import {
@@ -29,10 +30,15 @@ export const dynamic = "force-dynamic";
 const HEADER_FETCH_CONCURRENCY = 32;
 const TRAILER = new Uint8Array(TAR_TRAILER_LEN);
 
+// Bump if the encoded byte layout for the same inputs would change.
+// Invalidates all clients' If-Range validators.
+const TAR_LAYOUT_VERSION = "sda-tar-v1";
+
 type ResolvedEntry = {
   file: DatasetFile;
   headerBytes: Uint8Array;
   contentLen: number;
+  contentEtag: string;
   plan: PlannedEntry;
 };
 
@@ -152,6 +158,7 @@ export async function GET(
 
   const totalLen =
     resolved.reduce((sum, r) => sum + r.plan.entryLen, 0) + TAR_TRAILER_LEN;
+  const etag = computeTarEtag(resolved, sessionData.publicKey.pemChecksum);
 
   async function* emitTar(): AsyncGenerator<Buffer> {
     for (const r of resolved) {
@@ -234,6 +241,8 @@ export async function GET(
       "content-type": "application/x-tar",
       "content-length": String(totalLen),
       "cache-control": "no-store",
+      etag,
+      "accept-ranges": "bytes",
       "content-disposition": buildContentDisposition(`${datasetId}.tar`),
     },
   });
@@ -320,11 +329,23 @@ async function probeOne(
     contentHead.headers.get("content-length") || "0",
     10,
   );
+  // The /content ETag is recipient-independent and stable per fileId.
+  const contentEtag = contentHead.headers.get("etag") || `"${file.fileId}"`;
   const plan = planEntry(
     file.filePath,
     headerBytes.byteLength + contentLen,
     mtime,
   );
 
-  return { file, headerBytes, contentLen, plan };
+  return { file, headerBytes, contentLen, contentEtag, plan };
+}
+
+function computeTarEtag(entries: ResolvedEntry[], pemChecksum: string): string {
+  const h = crypto.createHash("sha256");
+  h.update(`${TAR_LAYOUT_VERSION}\n`);
+  h.update(`${pemChecksum}\n`);
+  for (const e of entries) {
+    h.update(`${e.file.fileId}\t${e.contentEtag}\t${e.file.filePath}\n`);
+  }
+  return `"${h.digest("hex").slice(0, 32)}"`;
 }

--- a/frontend/src/app/api/datasets/[datasetId]/download.tar/route.ts
+++ b/frontend/src/app/api/datasets/[datasetId]/download.tar/route.ts
@@ -208,7 +208,11 @@ async function handle(
     );
   }
 
-  const effectiveRange = range;
+  // Refuse to resume from a position that falls inside a c4gh header
+  // to avoid corrupting the tar since header bytes are unstable.
+  // Same rule as the per-file download in the proxy.
+  const effectiveRange =
+    range && !isInsideC4ghHeader(regions, range.start) ? range : null;
 
   const isPartial = effectiveRange !== null;
   const start = effectiveRange ? effectiveRange.start : 0;
@@ -525,3 +529,11 @@ function findRegionIndex(regions: Region[], pos: number): number {
   return lo;
 }
 
+// Returns true if range position lies inside a re-encrypted c4gh header region.
+function isInsideC4ghHeader(regions: Region[], pos: number): boolean {
+  const idx = findRegionIndex(regions, pos);
+  const r = regions[idx];
+  if (!r) return false;
+  if (r.start > pos || pos >= r.start + r.len) return false;
+  return r.kind === "static" && r.tag === "c4gh-header";
+}

--- a/frontend/src/app/api/datasets/[datasetId]/download.tar/route.ts
+++ b/frontend/src/app/api/datasets/[datasetId]/download.tar/route.ts
@@ -243,6 +243,13 @@ async function handle(
     let idx = findRegionIndex(regions, pos);
     const endExclusive = end + 1;
 
+    // Only emit chunks that do not terminate at a c4gh-header boundary.
+    // When we'd yield a c4gh header region, we hold it back and concatenate
+    // with the next chunk. The consumer never observes a yield boundary mid-header,
+    // so the natural pause point can't land inside one. This just avoids ever offering
+    // the browser the chance to resume mid-header.
+    let pendingHeader: Buffer | null = null;
+
     while (pos < endExclusive && idx < regions.length) {
       const r = regions[idx];
       const within = pos - r.start;
@@ -252,7 +259,19 @@ async function handle(
         // Use the c4gh header bytes (or pax/ustar/padding/trailer) we already
         // have from the preparatory phase. Slice for partial regions.
         const view = r.bytes.subarray(within, within + want);
-        yield Buffer.from(view.buffer, view.byteOffset, view.byteLength);
+        const slice = Buffer.from(
+          view.buffer,
+          view.byteOffset,
+          view.byteLength,
+        );
+        if (r.tag === "c4gh-header") {
+          pendingHeader = pendingHeader
+            ? Buffer.concat([pendingHeader, slice])
+            : slice;
+        } else {
+          yield pendingHeader ? Buffer.concat([pendingHeader, slice]) : slice;
+          pendingHeader = null;
+        }
         pos += want;
         idx++;
         continue;
@@ -286,8 +305,14 @@ async function handle(
           if (done) break;
           if (value && value.byteLength > 0) {
             const useLen = Math.min(value.byteLength, want - streamed);
+            const slice = Buffer.from(value.buffer, value.byteOffset, useLen);
             streamed += useLen;
-            yield Buffer.from(value.buffer, value.byteOffset, useLen);
+            if (pendingHeader) {
+              yield Buffer.concat([pendingHeader, slice]);
+              pendingHeader = null;
+            } else {
+              yield slice;
+            }
             if (streamed >= want) break;
           }
         }
@@ -306,6 +331,10 @@ async function handle(
       pos += want;
       idx++;
     }
+
+    // Flush any pendingHeader bytes (only possible if a c4gh header sits at the very
+    // end of the requested range and there's nothing after it to coalesce with).
+    if (pendingHeader) yield pendingHeader;
   }
 
   // Readable.from pulls from the generator on demand. If the browser slows

--- a/frontend/src/app/api/datasets/[datasetId]/download.tar/route.ts
+++ b/frontend/src/app/api/datasets/[datasetId]/download.tar/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { Readable } from "node:stream";
 import * as crypto from "crypto";
 import { getSession } from "@/app/lib/session";
@@ -15,6 +15,7 @@ import {
   extractProblemDetail,
   translateUpstreamError,
   buildContentDisposition,
+  parseRange,
 } from "@/app/lib/proxy";
 import {
   planEntry,
@@ -29,6 +30,7 @@ export const dynamic = "force-dynamic";
 
 const HEADER_FETCH_CONCURRENCY = 32;
 const TRAILER = new Uint8Array(TAR_TRAILER_LEN);
+const ZEROS_512 = new Uint8Array(TAR_BLOCK_SIZE);
 
 // Bump if the encoded byte layout for the same inputs would change.
 // Invalidates all clients' If-Range validators.
@@ -42,11 +44,37 @@ type ResolvedEntry = {
   plan: PlannedEntry;
 };
 
+type StaticTag = "pax" | "ustar" | "c4gh-header" | "padding" | "trailer";
+
+type Region =
+  | {
+      kind: "static";
+      tag: StaticTag;
+      bytes: Uint8Array;
+      start: number;
+      len: number;
+    }
+  | { kind: "content"; entryIndex: number; start: number; len: number };
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ datasetId: string }> },
 ) {
-  const { datasetId } = await params;
+  return handle(request, await params, "GET");
+}
+
+export async function HEAD(
+  request: NextRequest,
+  { params }: { params: Promise<{ datasetId: string }> },
+) {
+  return handle(request, await params, "HEAD");
+}
+
+async function handle(
+  request: NextRequest,
+  { datasetId }: { datasetId: string },
+  method: "GET" | "HEAD",
+): Promise<Response> {
   const signal = request.signal;
 
   const sessionData = await getSession();
@@ -158,26 +186,92 @@ export async function GET(
 
   const totalLen =
     resolved.reduce((sum, r) => sum + r.plan.entryLen, 0) + TAR_TRAILER_LEN;
+  const regions = buildRegions(resolved, totalLen);
   const etag = computeTarEtag(resolved, sessionData.publicKey.pemChecksum);
 
-  async function* emitTar(): AsyncGenerator<Buffer> {
-    for (const r of resolved) {
-      if (r.plan.paxBlock) yield Buffer.from(r.plan.paxBlock);
-      yield Buffer.from(r.plan.ustarBlock);
+  // If-Range only honors the Range when the validator still matches.
+  const ifRange = request.headers.get("if-range");
+  const honorRange = !ifRange || ifRange === etag;
+  const rangeHeader = honorRange ? request.headers.get("range") : null;
+  const range = parseRange(rangeHeader, totalLen);
 
-      // Use the c4gh header bytes we already have from preparatory phase.
-      if (r.headerBytes.byteLength > 0) yield Buffer.from(r.headerBytes);
+  if (range === "unsatisfiable") {
+    return NextResponse.json(
+      { error: "The requested byte range is not satisfiable.", status: 416 },
+      {
+        status: 416,
+        headers: {
+          "cache-control": "no-store",
+          "content-range": `bytes */${totalLen}`,
+        },
+      },
+    );
+  }
+
+  const effectiveRange = range;
+
+  const isPartial = effectiveRange !== null;
+  const start = effectiveRange ? effectiveRange.start : 0;
+  const end = effectiveRange ? effectiveRange.end : totalLen - 1;
+  const length = end - start + 1;
+
+  const responseHeaders = new Headers({
+    "content-type": "application/x-tar",
+    "accept-ranges": "bytes",
+    "cache-control": "no-store",
+    etag,
+    "content-disposition": buildContentDisposition(`${datasetId}.tar`),
+    "content-length": String(length),
+  });
+  if (isPartial) {
+    responseHeaders.set("content-range", `bytes ${start}-${end}/${totalLen}`);
+  }
+
+  if (method === "HEAD") {
+    return new Response(null, {
+      status: isPartial ? 206 : 200,
+      headers: responseHeaders,
+    });
+  }
+
+  async function* emitTar(): AsyncGenerator<Buffer> {
+    let pos = start;
+    let idx = findRegionIndex(regions, pos);
+    const endExclusive = end + 1;
+
+    while (pos < endExclusive && idx < regions.length) {
+      const r = regions[idx];
+      const within = pos - r.start;
+      const want = Math.min(r.len - within, endExclusive - pos);
+
+      if (r.kind === "static") {
+        // Use the c4gh header bytes (or pax/ustar/padding/trailer) we already
+        // have from the preparatory phase. Slice for partial regions.
+        const view = r.bytes.subarray(within, within + want);
+        yield Buffer.from(view.buffer, view.byteOffset, view.byteLength);
+        pos += want;
+        idx++;
+        continue;
+      }
 
       // Stream the content, verify the content length here to ensure data integrity.
-      const contentUrl = `${sdaBaseUrl}/files/${encodeURIComponent(r.file.fileId)}/content`;
+      const e = resolved[r.entryIndex];
+      const contentUrl = `${sdaBaseUrl}/files/${encodeURIComponent(e.file.fileId)}/content`;
+      const reqHeaders: Record<string, string> = {
+        Authorization: `Bearer ${token}`,
+      };
+      const partial = within > 0 || want < r.len;
+      if (partial) {
+        reqHeaders["Range"] = `bytes=${within}-${within + want - 1}`;
+      }
       const contentResp = await fetch(contentUrl, {
-        headers: { Authorization: `Bearer ${token}` },
+        headers: reqHeaders,
         cache: "no-store",
         signal,
       });
       if (!contentResp.ok || !contentResp.body) {
         throw new Error(
-          `Failed to GET content for ${r.file.fileId}: ${contentResp.status}`,
+          `Failed to GET content for ${e.file.fileId}: ${contentResp.status}`,
         );
       }
       const reader = contentResp.body.getReader();
@@ -187,8 +281,10 @@ export async function GET(
           const { done, value } = await reader.read();
           if (done) break;
           if (value && value.byteLength > 0) {
-            streamed += value.byteLength;
-            yield Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+            const useLen = Math.min(value.byteLength, want - streamed);
+            streamed += useLen;
+            yield Buffer.from(value.buffer, value.byteOffset, useLen);
+            if (streamed >= want) break;
           }
         }
       } finally {
@@ -198,18 +294,14 @@ export async function GET(
           // best-effort
         }
       }
-      if (streamed !== r.contentLen) {
+      if (streamed !== want) {
         throw new Error(
-          `Content length mismatch for ${r.file.fileId}: expected ${r.contentLen}, got ${streamed}`,
+          `Content length mismatch for ${e.file.fileId}: expected ${want}, got ${streamed}`,
         );
       }
-
-      // Pad the entry to a 512-byte boundary so the next entry's header
-      // block starts on a clean offset (TAR requirement).
-      if (r.plan.paddingLen > 0) yield Buffer.alloc(r.plan.paddingLen);
+      pos += want;
+      idx++;
     }
-    // TAR trailer: two zero blocks
-    yield Buffer.from(TRAILER);
   }
 
   // Readable.from pulls from the generator on demand. If the browser slows
@@ -236,15 +328,8 @@ export async function GET(
   ) as unknown as ReadableStream<Uint8Array>;
 
   return new Response(webStream, {
-    status: 200,
-    headers: {
-      "content-type": "application/x-tar",
-      "content-length": String(totalLen),
-      "cache-control": "no-store",
-      etag,
-      "accept-ranges": "bytes",
-      "content-disposition": buildContentDisposition(`${datasetId}.tar`),
-    },
+    status: isPartial ? 206 : 200,
+    headers: responseHeaders,
   });
 }
 
@@ -329,7 +414,7 @@ async function probeOne(
     contentHead.headers.get("content-length") || "0",
     10,
   );
-  // The /content ETag is recipient-independent and stable per fileId.
+  // The /content ETag is recipient-independent and stable per backend api specification.
   const contentEtag = contentHead.headers.get("etag") || `"${file.fileId}"`;
   const plan = planEntry(
     file.filePath,
@@ -340,6 +425,9 @@ async function probeOne(
   return { file, headerBytes, contentLen, contentEtag, plan };
 }
 
+// ETag bound to encoder version, recipient key, and per-entry id + upstream content ETag
+// + path. We deliberately exclude c4gh header bytes since we disallow mid-header resumes
+// since these headers are unstable per spec.
 function computeTarEtag(entries: ResolvedEntry[], pemChecksum: string): string {
   const h = crypto.createHash("sha256");
   h.update(`${TAR_LAYOUT_VERSION}\n`);
@@ -349,3 +437,91 @@ function computeTarEtag(entries: ResolvedEntry[], pemChecksum: string): string {
   }
   return `"${h.digest("hex").slice(0, 32)}"`;
 }
+
+// Build the byte layout map: each region is either an in-memory `static`
+// block (pax/ustar/c4gh-header/padding/trailer) or a `content` placeholder
+// that streams from /content.
+function buildRegions(entries: ResolvedEntry[], totalLen: number): Region[] {
+  const regions: Region[] = [];
+  let cursor = 0;
+  for (let i = 0; i < entries.length; i++) {
+    const e = entries[i];
+    if (e.plan.paxBlock) {
+      regions.push({
+        kind: "static",
+        tag: "pax",
+        bytes: e.plan.paxBlock,
+        start: cursor,
+        len: e.plan.paxBlock.length,
+      });
+      cursor += e.plan.paxBlock.length;
+    }
+    regions.push({
+      kind: "static",
+      tag: "ustar",
+      bytes: e.plan.ustarBlock,
+      start: cursor,
+      len: TAR_BLOCK_SIZE,
+    });
+    cursor += TAR_BLOCK_SIZE;
+    if (e.headerBytes.length > 0) {
+      regions.push({
+        kind: "static",
+        tag: "c4gh-header",
+        bytes: e.headerBytes,
+        start: cursor,
+        len: e.headerBytes.length,
+      });
+      cursor += e.headerBytes.length;
+    }
+    if (e.contentLen > 0) {
+      regions.push({
+        kind: "content",
+        entryIndex: i,
+        start: cursor,
+        len: e.contentLen,
+      });
+      cursor += e.contentLen;
+    }
+    if (e.plan.paddingLen > 0) {
+      // Pad the entry to a 512-byte boundary so the next entry's header
+      // block starts on a clean offset (TAR requirement).
+      regions.push({
+        kind: "static",
+        tag: "padding",
+        bytes: ZEROS_512.subarray(0, e.plan.paddingLen),
+        start: cursor,
+        len: e.plan.paddingLen,
+      });
+      cursor += e.plan.paddingLen;
+    }
+  }
+  // TAR trailer: two zero blocks
+  regions.push({
+    kind: "static",
+    tag: "trailer",
+    bytes: TRAILER,
+    start: cursor,
+    len: TAR_TRAILER_LEN,
+  });
+  cursor += TAR_TRAILER_LEN;
+  if (cursor !== totalLen) {
+    throw new Error(
+      `Internal error: region cursor ${cursor} !== totalLen ${totalLen}`,
+    );
+  }
+  return regions;
+}
+
+function findRegionIndex(regions: Region[], pos: number): number {
+  let lo = 0;
+  let hi = regions.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    const r = regions[mid];
+    if (r.start + r.len <= pos) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+

--- a/frontend/src/app/api/files/[fileId]/route.ts
+++ b/frontend/src/app/api/files/[fileId]/route.ts
@@ -6,6 +6,7 @@ import {
   extractProblemDetail,
   translateUpstreamError,
   buildContentDisposition,
+  parseRange,
 } from "@/app/lib/proxy";
 
 function getFallbackFilename(filePath: string | null, fileId: string): string {
@@ -14,26 +15,6 @@ function getFallbackFilename(filePath: string | null, fileId: string): string {
     if (basename) return basename;
   }
   return `${fileId}.c4gh`; //2nd fallback
-}
-
-type Range = { start: number; end: number };
-
-// Parse a single-range "bytes=<start>-<end?>" header in combined-stream space.
-// Returns null if not present/unparseable or "unsatisfiable" if start >= totalLen or start > end.
-function parseRange(
-  header: string | null,
-  totalLen: number,
-): Range | "unsatisfiable" | null {
-  if (!header) return null;
-
-  const m = header.match(/^bytes=(\d+)-(\d*)$/);
-  if (!m) return null;
-
-  const start = parseInt(m[1], 10);
-  const end = m[2] ? parseInt(m[2], 10) : totalLen - 1;
-  if (start >= totalLen || start > end) return "unsatisfiable";
-
-  return { start, end: Math.min(end, totalLen - 1) };
 }
 
 export async function GET(

--- a/frontend/src/app/lib/proxy.ts
+++ b/frontend/src/app/lib/proxy.ts
@@ -45,3 +45,23 @@ export function buildContentDisposition(filename: string): string {
   const encoded = encodeURIComponent(filename);
   return `attachment; filename="${filename}"; filename*=UTF-8''${encoded}`;
 }
+
+export type Range = { start: number; end: number };
+
+// Parse a single-range "bytes=<start>-<end?>" header in combined-stream space.
+// Returns null if not present/unparseable or "unsatisfiable" if start >= totalLen or start > end.
+export function parseRange(
+  header: string | null,
+  totalLen: number,
+): Range | "unsatisfiable" | null {
+  if (!header) return null;
+
+  const m = header.match(/^bytes=(\d+)-(\d*)$/);
+  if (!m) return null;
+
+  const start = parseInt(m[1], 10);
+  const end = m[2] ? parseInt(m[2], 10) : totalLen - 1;
+  if (start >= totalLen || start > end) return "unsatisfiable";
+
+  return { start, end: Math.min(end, totalLen - 1) };
+}


### PR DESCRIPTION
## Related issue(s) and PR(s)

This PR closes #117  and is a continuation of #116. 

It extends the  batch TAR download endpoint of #116 to support native browser
resume via HTTP Range. 

Again a somewhat lengthy description of the logic:

1. #116 made sure that the TAR's byte layout is deterministic.
2. Here we add a **region map** that is built during the preparation phase. Every byte of the response is tagged as belonging to one of two kinds of region: `static` (in-memory bytes we already have: PAX block, USTAR block, c4gh header, padding, trailer) or `content` (must be fetched from `/files/{id}/content`).
3. A **stable archive (TAR) ETag** is computed from the encoder version, the recipient's PEM checksum, and per-entry `(fileId, content ETag, filePath)`. It deliberately excludes the cached c4gh header bytes so it stays stable for the same recipient and selection. `If-Range` is honored only when this ETag matches.
4. A new `HEAD` handler returns the same headers a `GET` would so that any client that wants to pre-size a transfer can do it cheaply.
5. **Range requests** translate into a walk of the region map starting at the requested offset, slicing static regions and issuing upstream `Range` requests for content regions when only part is needed.

**Note 1**: the encoder version is just a way to document the tar library that was added in #116 since changing this file e.g. modifications in the tar lib that affect block sizes etc (there is no reaosn to do this but who knows) will result in corrupting resumed tars that where originally created by the previous code version.

**Note 2**: Since Crypt4GH headers are size stable but byte unstable, we deny resuming mid-header, similarly as we do with per-file downloads, restarting from scratch instead in such a case. 
Effort was made to minimize such denials by placing a second guard in place. This avoids serving data chunks that end with c4gh header bytes. Instead in such cases it always concatenate with the next chunk and serve them together. This mechanism eliminates the chance that a download is interrupted mid-header if the user presses `pause`, hence the browsers stops gracefully. It may also catch more abrupt interruptions but given that headers are super small as compared to the content, I think this the best that we can do either way.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Instructions on how to test

The route's test suite is expanded to cover as much cases as possible (including some edge cases).

To test the resume, follow test instructions of #116 and try to download the 2nd dataset that has a 2Gb file. Pause and resume as much as you like. You can also try to kill the browser and open it again. After the resume picks up and the file is downloaded, validate integrity of files as described in #116.

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] All Acceptance Criteria (AC) Fulfilled and checked in the Related issue
