### PR TITLE
129 detect expired sessions

### DIFF
--- a/frontend/src/app/api/files/[fileId]/route.test.ts
+++ b/frontend/src/app/api/files/[fileId]/route.test.ts
@@ -208,24 +208,19 @@ describe("GET /api/files/[fileId]", () => {
     vi.restoreAllMocks();
   });
 
-  test("returns 401 when no session token is present", async () => {
+  test("redirects to /userinfo when no session token is present", async () => {
     setSession(null);
     const fetchSpy = vi.spyOn(globalThis, "fetch");
 
     const { request, params } = makeRequest("file-1");
     const response = await GET(request, { params });
 
-    expect(response.status).toBe(401);
-    expect(response.headers.get("cache-control")).toBe("no-store");
-    expect(response.headers.get("content-disposition")).toBeNull();
-    await expect(response.json()).resolves.toMatchObject({
-      error: "Not authenticated.",
-      status: 401,
-    });
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toMatch(/\/userinfo$/);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  test("returns 401 when resuming a download without a session token", async () => {
+  test("redirects to /userinfo when resuming a download without a session token", async () => {
     setSession(null);
     const fetchSpy = vi.spyOn(globalThis, "fetch");
 
@@ -235,15 +230,8 @@ describe("GET /api/files/[fileId]", () => {
 
     const response = await GET(request, { params });
 
-    expect(response.status).toBe(401);
-    expect(response.headers.get("cache-control")).toBe("no-store");
-    expect(response.headers.get("content-disposition")).toBeNull();
-
-    await expect(response.json()).resolves.toMatchObject({
-      error: "Not authenticated.",
-      status: 401,
-    });
-
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toMatch(/\/userinfo$/);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/app/api/files/[fileId]/route.ts
+++ b/frontend/src/app/api/files/[fileId]/route.ts
@@ -45,7 +45,10 @@ export async function GET(
   const filePath = request.nextUrl.searchParams.get("name");
 
   if (!sessionData?.token) {
-    return errorResponse(401, "Not authenticated.");
+    return new NextResponse(null, {
+      status: 307,
+      headers: { location: "/userinfo" },
+    });
   }
 
   if (!sessionData.publicKey?.key) {

--- a/frontend/src/app/components/SessionExpiryWatcher.tsx
+++ b/frontend/src/app/components/SessionExpiryWatcher.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function SessionExpiryWatcher({ expiresAt }: { expiresAt: number }) {
+  useEffect(() => {
+    const ms = expiresAt - Date.now();
+    if (ms <= 0) {
+      location.reload();
+      return;
+    }
+    const id = setTimeout(() => location.reload(), ms + 1000);
+    return () => clearTimeout(id);
+  }, [expiresAt]);
+
+  return null;
+}

--- a/frontend/src/app/components/SessionExpiryWatcher.tsx
+++ b/frontend/src/app/components/SessionExpiryWatcher.tsx
@@ -2,15 +2,26 @@
 
 import { useEffect } from "react";
 
+// Check every 20 days at most to check if the session has expired, and reload if so.
+// This is a workaround to the 32-bit timeout limitation in html spec.
+const MAX_DELAY = 20 * 24 * 60 * 60 * 1000; // 20 days in ms
+
 export function SessionExpiryWatcher({ expiresAt }: { expiresAt: number }) {
   useEffect(() => {
-    const ms = expiresAt - Date.now();
-    if (ms <= 0) {
-      location.reload();
-      return;
-    }
-    const id = setTimeout(() => location.reload(), ms + 1000);
-    return () => clearTimeout(id);
+    let timerId: ReturnType<typeof setTimeout>;
+
+    const schedule = () => {
+      const remaining = expiresAt - Date.now();
+      if (remaining <= 0) {
+        location.reload();
+        return;
+      }
+      const delay = Math.min(remaining + 1000, MAX_DELAY);
+      timerId = setTimeout(schedule, delay);
+    };
+
+    schedule();
+    return () => clearTimeout(timerId);
   }, [expiresAt]);
 
   return null;

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -4,23 +4,28 @@ import "bootstrap-icons/font/bootstrap-icons.css";
 import BootstrapClient from "@/app/components/BootstrapClient";
 import "./globals.scss";
 import { Header } from "./components/Header";
+import { SessionExpiryWatcher } from "./components/SessionExpiryWatcher";
+import { getSession } from "./lib/session";
+import { decodeJwt } from "jose";
 
 export const metadata: Metadata = {
   title: "SDA Download UI",
   description: "An UI for the SDA download",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+}: Readonly<{ children: React.ReactNode }>) {
+  const session = await getSession();
+  const exp = session?.token ? decodeJwt(session.token).exp : undefined;
+
   return (
     <html lang="en">
       <body>
         <Header />
         <BootstrapClient />
         {children}
+        {exp && <SessionExpiryWatcher expiresAt={exp * 1000} />}
       </body>
     </html>
   );


### PR DESCRIPTION
## Related issue(s) and PR(s)

This PR closes #129.

This fixes the following gaps in how the UI handled expired sessions:

-  Idle pages didn't notice session expiry so that a page that was loaded while signed in stayed visible indefinitely after the session expired. The user only discovered the problem when they clicked something that hit the server.
- If someone pasted the url link of a single file download we returned a 401 status that  leaked raw JSON instead of a user-friendly page.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## List of changes made

- New client component `SessionExpiryWatcher` that sets a timeout from the JWT's `exp` and reloads the page when it is exceeded so that the existing `LoginRequiredAlert` on each protected page surfaces naturally.

**2. Graceful 401 on the file download route**

- `/api/files/[fileId]` no longer returns `401 + JSON` when there's no session token. It now responds with a `307` redirect to `/userinfo`, which already renders `LoginRequiredAlert` and a Sign in button.
- affected tests were updated for the new behavior

## Testing

- Instructions on how to test

Do `docker compose -f sda-dev-stack.yml --profile sda-auth down` then set `access-token-validity-seconds: 60` in  `dev-tools/aai-mock/clients/sdad.yml`  and then `docker compose -f sda-dev-stack.yml --profile sda-auth up` again. Now the token lifetime is 1 min.

Open SDAD, upload a pub key, go to files of a dataset and copy the download url of a file. just wait. After 1 min you should see the session expiration alert. 

Try now to paste the copied url in the browser. You should get the same token expiration page now instead of a json payload.

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] All Acceptance Criteria (AC) Fulfilled and checked in the Related issue
