### PR TITLE
fix: stripping the file extention from the file path issue #122

### DIFF
--- a/frontend/src/app/actions/checksums.test.ts
+++ b/frontend/src/app/actions/checksums.test.ts
@@ -9,7 +9,7 @@ import {
 const files: DatasetFile[] = [
   {
     fileId: "file-1",
-    filePath: "folder/file-1.cram",
+    filePath: "folder/file-1.c4gh",
     size: 100,
     decryptedSize: 90,
     checksums: [
@@ -26,7 +26,7 @@ const files: DatasetFile[] = [
   },
   {
     fileId: "file-2",
-    filePath: "folder/file-2.cram",
+    filePath: "folder/file-2.c4gh",
     size: 200,
     decryptedSize: 180,
     checksums: [
@@ -39,7 +39,7 @@ const files: DatasetFile[] = [
   },
   {
     fileId: "file-3",
-    filePath: "folder/file-3.cram",
+    filePath: "folder/file-3.c4gh",
     size: 150,
     decryptedSize: 120,
     checksums: [
@@ -92,9 +92,9 @@ describe("createChecksumFileContent", () => {
   it("creates checksum file content compatible with sha256sum and md5sum", () => {
     expect(createChecksumFileContent(files, "sha256")).toBe(
       [
-        "sha256-checksum-file-1  folder/file-1.cram",
-        "sha256-checksum-file-2  folder/file-2.cram",
-        "sha256-checksum-file-3  folder/file-3.cram",
+        "sha256-checksum-file-1  folder/file-1",
+        "sha256-checksum-file-2  folder/file-2",
+        "sha256-checksum-file-3  folder/file-3",
         "",
       ].join("\n"),
     );
@@ -102,7 +102,7 @@ describe("createChecksumFileContent", () => {
 
   it("throws an error when a file is missing the requested checksum type", () => {
     expect(() => createChecksumFileContent(files, "md5")).toThrow(
-      "Missing md5 checksum for file: folder/file-2.cram",
+      "Missing md5 checksum for file: folder/file-2.c4gh",
     );
   });
 });

--- a/frontend/src/app/actions/checksums.ts
+++ b/frontend/src/app/actions/checksums.ts
@@ -32,8 +32,11 @@ export function createChecksumFileContent(
             `Missing ${checksumType} checksum for file: ${file.filePath}`,
           );
         }
+        // Decrypted filenames, i.e. same names but without .c4gh extension
+        const fileExt = ".c4gh";
+        const decryptedFilename = file.filePath.replace(fileExt, "");
 
-        return `${checksum}  ${file.filePath}`;
+        return `${checksum}  ${decryptedFilename}`;
       })
       .join("\n") + "\n"
   );


### PR DESCRIPTION
## Related issue

This PR closes #122 .

The decrypted file name is the filePath minus the file extension ".c4gh"

## Bug description

Downloading checksums should give the filename without file extention f.e test-file and not test-file.c4gh

## Fix implemented

Removed the file extention

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
- [x] Relevant tests have been added or updated
- [x] The fix has been verified manually, if applicable
