### PR TITLE
119 dataset download via sda cli

### DIFF
--- a/frontend/src/app/components/ChecksumExportActions.tsx
+++ b/frontend/src/app/components/ChecksumExportActions.tsx
@@ -8,6 +8,7 @@ import {
   downloadTextFile,
 } from "../actions/checksums";
 import Alert from "@/app/components/Alert";
+import DropdownButton from "@/app/components/DropdownButton";
 
 type ChecksumExportActionsProps = {
   files: DatasetFile[];
@@ -53,37 +54,22 @@ export function ChecksumExportActions({
         />
       )}
       <form autoComplete="off">
-        <div className="dropdown">
-          <button
-            className="btn btn-outline-primary dropdown-toggle"
-            type="button"
-            data-bs-toggle="dropdown"
-            aria-expanded="false"
-            disabled={selectedFiles.length === 0}
-          >
-            Export options
-          </button>
-          <ul className="dropdown-menu">
-            <li>
-              <button
-                className="dropdown-item"
-                onClick={() => handleChecksumExport("sha256")}
-                disabled={!canExportSha256}
-              >
-                Export SHA256 checksums
-              </button>
-            </li>
-            <li>
-              <button
-                className="dropdown-item"
-                onClick={() => handleChecksumExport("md5")}
-                disabled={!canExportMd5}
-              >
-                Export md5 checksums
-              </button>
-            </li>
-          </ul>
-        </div>
+        <DropdownButton
+          label="Export options"
+          disabled={selectedFiles.length === 0}
+          items={[
+            {
+              label: "Export SHA256 checksums",
+              onClick: () => handleChecksumExport("sha256"),
+              disabled: !canExportSha256,
+            },
+            {
+              label: "Export md5 checksums",
+              onClick: () => handleChecksumExport("md5"),
+              disabled: !canExportMd5,
+            },
+          ]}
+        />
       </form>
     </div>
   );

--- a/frontend/src/app/components/DatasetDetails.tsx
+++ b/frontend/src/app/components/DatasetDetails.tsx
@@ -1,7 +1,9 @@
+"use client";
 import { DatasetMetadata, DatasetFile } from "../actions/datasets";
 import { filesize } from "filesize";
 import InfoTooltip from "./InfoTooltip";
 import DownloadChecksumsButton from "./DownloadChecksumsButton";
+import { DownloadActions } from "@/app/components/DownloadActions";
 
 type DatasetDetailsProps = {
   dataset: DatasetMetadata;
@@ -50,6 +52,7 @@ export default function DatasetDetails({
               files={files}
               datasetId={dataset.datasetId}
             />
+            <DownloadActions datasetId={dataset.datasetId} />
           </div>
         </div>
       </div>

--- a/frontend/src/app/components/DatasetDetails.tsx
+++ b/frontend/src/app/components/DatasetDetails.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { DatasetMetadata, DatasetFile } from "../actions/datasets";
 import { filesize } from "filesize";
 import InfoTooltip from "./InfoTooltip";
@@ -45,14 +44,11 @@ export default function DatasetDetails({
             </span>
           </div>
           <div className="d-flex justify-content-start mt-3">
-            <button className="btn btn-primary align-self-start me-3">
-              Download dataset
-            </button>
+            <DownloadActions datasetId={dataset.datasetId} />
             <DownloadChecksumsButton
               files={files}
               datasetId={dataset.datasetId}
             />
-            <DownloadActions datasetId={dataset.datasetId} />
           </div>
         </div>
       </div>

--- a/frontend/src/app/components/DatasetDetails.tsx
+++ b/frontend/src/app/components/DatasetDetails.tsx
@@ -4,7 +4,6 @@ import { DownloadActions } from "@/app/components/DownloadActions";
 import DatasetSize from "./DatasetSize";
 import { formatDatasetDate, formatFileCount } from "../lib/datasetFormat";
 
-
 type DatasetDetailsProps = {
   dataset: DatasetMetadata;
   files: DatasetFile[];

--- a/frontend/src/app/components/DownloadActions.tsx
+++ b/frontend/src/app/components/DownloadActions.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+type DownloadActionsProps = {
+  datasetId: string;
+};
+
+export function DownloadActions(datasetId: DownloadActionsProps) {
+  const command = `sda-cli --config <configuration_file> download \\
+  --pubkey <public-key-file> \\
+  --dataset-id ${datasetId} \\
+  --url <downloadServiceUrl> \\
+  --outdir <outdir> \\
+  --dataset`;
+
+  const copyCommand = () => {
+    navigator.clipboard.writeText(command);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        className="btn btn-primary me-3"
+        data-bs-toggle="modal"
+        data-bs-target="#cliModal"
+      >
+        Download via sda-cli
+      </button>
+
+      <div
+        className="modal fade"
+        id="cliModal"
+        tabIndex="-1"
+        aria-labelledby="cliModalLabel"
+        aria-hidden="true"
+      >
+        <div className="modal-dialog">
+          <div className="modal-content">
+            <div className="modal-header">
+              <h1 className="modal-title fs-5" id="cliModalLabel">
+                Download via sda-cli command
+              </h1>
+              <button
+                type="button"
+                className="btn-close"
+                data-bs-dismiss="modal"
+                aria-label="Close"
+              ></button>
+            </div>
+            <div className="modal-body">{command}</div>
+            <div className="modal-footer">
+              <button
+                type="button"
+                className="btn btn-secondary"
+                data-bs-dismiss="modal"
+              >
+                Close
+              </button>
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={copyCommand}
+              >
+                <i className="bi bi-copy"></i>Copy command
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/app/components/DownloadActions.tsx
+++ b/frontend/src/app/components/DownloadActions.tsx
@@ -54,7 +54,6 @@ export function DownloadActions({ datasetId }: DownloadActionsProps) {
     <>
       <DropdownButton
         label="Download options"
-        className="btn btn-outline-primary dropdown-toggle me-3"
         items={[
           {
             label: "Download via sda-cli",

--- a/frontend/src/app/components/DownloadActions.tsx
+++ b/frontend/src/app/components/DownloadActions.tsx
@@ -2,12 +2,13 @@
 
 import { useState } from "react";
 import { ModalDialog } from "@/app/components/ModalDialog";
+import DropdownButton from "@/app/components/DropdownButton";
 
 type DownloadActionsProps = {
   datasetId: string;
 };
 
-export function DownloadActions({datasetId}: DownloadActionsProps) {
+export function DownloadActions({ datasetId }: DownloadActionsProps) {
   const [copied, setCopied] = useState(false);
   const command = [
     "sda-cli --config <configuration_file> download \\",
@@ -27,13 +28,13 @@ export function DownloadActions({datasetId}: DownloadActionsProps) {
       </p>
 
       <p>
-        Replace the values inside angle brackets, such as{" "}
+        After copying the command replace the values inside angle brackets,
+          such as{" "}
         <code>&lt;configuration_file&gt;</code>,{" "}
         <code>&lt;public-key-file&gt;</code>,{" "}
         <code>&lt;download-service-url&gt;</code>, and{" "}
         <code>&lt;outdir&gt;</code>, with paths or values for your local setup.
       </p>
-
       <pre className="p-3 mb-2 bg-light rounded">
         <code>{command}</code>
       </pre>
@@ -52,28 +53,16 @@ export function DownloadActions({datasetId}: DownloadActionsProps) {
 
   return (
     <>
-      <div className="dropdown">
-        <button
-          className="btn btn-outline-primary dropdown-toggle me-3"
-          type="button"
-          data-bs-toggle="dropdown"
-          aria-expanded="false"
-        >
-          Download options
-        </button>
-        <ul className="dropdown-menu">
-          <li>
-            <button
-              type="button"
-              className="dropdown-item"
-              data-bs-toggle="modal"
-              data-bs-target="#cliModal"
-            >
-              Download via sda-cli
-            </button>
-          </li>
-        </ul>
-      </div>
+      <DropdownButton
+        label="Download options"
+        className="btn btn-outline-primary dropdown-toggle me-3"
+        items={[
+          {
+            label: "Download via sda-cli",
+            modalTarget: "#cliModal",
+          },
+        ]}
+      />
       <ModalDialog
         id="cliModal"
         title="Download via sda-cli command"

--- a/frontend/src/app/components/DownloadActions.tsx
+++ b/frontend/src/app/components/DownloadActions.tsx
@@ -28,9 +28,8 @@ export function DownloadActions({ datasetId }: DownloadActionsProps) {
       </p>
 
       <p>
-        After copying the command replace the values inside angle brackets,
-          such as{" "}
-        <code>&lt;configuration_file&gt;</code>,{" "}
+        After copying the command replace the values inside angle brackets, such
+        as <code>&lt;configuration_file&gt;</code>,{" "}
         <code>&lt;public-key-file&gt;</code>,{" "}
         <code>&lt;download-service-url&gt;</code>, and{" "}
         <code>&lt;outdir&gt;</code>, with paths or values for your local setup.

--- a/frontend/src/app/components/DownloadActions.tsx
+++ b/frontend/src/app/components/DownloadActions.tsx
@@ -7,25 +7,54 @@ type DownloadActionsProps = {
   datasetId: string;
 };
 
-export function DownloadActions(datasetId: DownloadActionsProps) {
+export function DownloadActions({datasetId}: DownloadActionsProps) {
   const [copied, setCopied] = useState(false);
-  const command = `sda-cli --config <configuration_file> download \\
-  --pubkey <public-key-file> \\
-  --dataset-id ${datasetId} \\
-  --url <downloadServiceUrl> \\
-  --outdir <outdir> \\
-  --dataset`;
+  const command = [
+    "sda-cli --config <configuration_file> download \\",
+    "--pubkey <public-key-file> \\",
+    `--dataset-id ${datasetId} \\`,
+    "--url <download-service-url> \\",
+    "--outdir <outdir> \\",
+    "--dataset",
+  ].join("\n");
+
+  const modalBody = (
+    <>
+      <p>
+        Use this command to download the full dataset with <code>sda-cli</code>.
+        The command assumes that credentials from <strong>SDA Login</strong> are
+        available in your config file.
+      </p>
+
+      <p>
+        Replace the values inside angle brackets, such as{" "}
+        <code>&lt;configuration_file&gt;</code>,{" "}
+        <code>&lt;public-key-file&gt;</code>,{" "}
+        <code>&lt;download-service-url&gt;</code>, and{" "}
+        <code>&lt;outdir&gt;</code>, with paths or values for your local setup.
+      </p>
+
+      <pre className="p-3 mb-2 bg-light rounded">
+        <code>{command}</code>
+      </pre>
+    </>
+  );
 
   const copyCommand = async () => {
     await navigator.clipboard.writeText(command);
     setCopied(true);
+
+    // Time out so that the button icon will go back to a copy symbol
+    setTimeout(() => {
+      setCopied(false);
+    }, 3000);
   };
 
   return (
     <>
       <div className="dropdown">
         <button
-          className="btn btn-secondary dropdown-toggle"
+          className="btn btn-outline-primary dropdown-toggle me-3"
           type="button"
           data-bs-toggle="dropdown"
           aria-expanded="false"
@@ -43,25 +72,16 @@ export function DownloadActions(datasetId: DownloadActionsProps) {
               Download via sda-cli
             </button>
           </li>
-          <li>
-            <a className="dropdown-item" href="#">
-              Another action
-            </a>
-          </li>
-          <li>
-            <a className="dropdown-item" href="#">
-              Something else here
-            </a>
-          </li>
         </ul>
       </div>
       <ModalDialog
         id="cliModal"
         title="Download via sda-cli command"
-        body={command}
+        body={modalBody}
         action={copyCommand}
-        iconClass={copied ? "bi-clipboard-check": "bi-copy" }
-        actionButtonLabel="Copy command"/>
+        iconClass={copied ? "bi-clipboard-check" : "bi-copy"}
+        actionButtonLabel="Copy command"
+      />
     </>
   );
 }

--- a/frontend/src/app/components/DownloadActions.tsx
+++ b/frontend/src/app/components/DownloadActions.tsx
@@ -1,10 +1,14 @@
 "use client";
 
+import { useState } from "react";
+import { ModalDialog } from "@/app/components/ModalDialog";
+
 type DownloadActionsProps = {
   datasetId: string;
 };
 
 export function DownloadActions(datasetId: DownloadActionsProps) {
+  const [copied, setCopied] = useState(false);
   const command = `sda-cli --config <configuration_file> download \\
   --pubkey <public-key-file> \\
   --dataset-id ${datasetId} \\
@@ -12,61 +16,52 @@ export function DownloadActions(datasetId: DownloadActionsProps) {
   --outdir <outdir> \\
   --dataset`;
 
-  const copyCommand = () => {
-    navigator.clipboard.writeText(command);
+  const copyCommand = async () => {
+    await navigator.clipboard.writeText(command);
+    setCopied(true);
   };
 
   return (
     <>
-      <button
-        type="button"
-        className="btn btn-primary me-3"
-        data-bs-toggle="modal"
-        data-bs-target="#cliModal"
-      >
-        Download via sda-cli
-      </button>
-
-      <div
-        className="modal fade"
-        id="cliModal"
-        tabIndex="-1"
-        aria-labelledby="cliModalLabel"
-        aria-hidden="true"
-      >
-        <div className="modal-dialog">
-          <div className="modal-content">
-            <div className="modal-header">
-              <h1 className="modal-title fs-5" id="cliModalLabel">
-                Download via sda-cli command
-              </h1>
-              <button
-                type="button"
-                className="btn-close"
-                data-bs-dismiss="modal"
-                aria-label="Close"
-              ></button>
-            </div>
-            <div className="modal-body">{command}</div>
-            <div className="modal-footer">
-              <button
-                type="button"
-                className="btn btn-secondary"
-                data-bs-dismiss="modal"
-              >
-                Close
-              </button>
-              <button
-                type="button"
-                className="btn btn-primary"
-                onClick={copyCommand}
-              >
-                <i className="bi bi-copy"></i>Copy command
-              </button>
-            </div>
-          </div>
-        </div>
+      <div className="dropdown">
+        <button
+          className="btn btn-secondary dropdown-toggle"
+          type="button"
+          data-bs-toggle="dropdown"
+          aria-expanded="false"
+        >
+          Download options
+        </button>
+        <ul className="dropdown-menu">
+          <li>
+            <button
+              type="button"
+              className="dropdown-item"
+              data-bs-toggle="modal"
+              data-bs-target="#cliModal"
+            >
+              Download via sda-cli
+            </button>
+          </li>
+          <li>
+            <a className="dropdown-item" href="#">
+              Another action
+            </a>
+          </li>
+          <li>
+            <a className="dropdown-item" href="#">
+              Something else here
+            </a>
+          </li>
+        </ul>
       </div>
+      <ModalDialog
+        id="cliModal"
+        title="Download via sda-cli command"
+        body={command}
+        action={copyCommand}
+        iconClass={copied ? "bi-clipboard-check": "bi-copy" }
+        actionButtonLabel="Copy command"/>
     </>
   );
 }

--- a/frontend/src/app/components/DownloadChecksumsButton.tsx
+++ b/frontend/src/app/components/DownloadChecksumsButton.tsx
@@ -41,7 +41,7 @@ export default function DownloadChecksumsButton({
   return (
     <button
       type="button"
-      className="btn btn-primary align-self-start"
+      className="btn btn-primary align-self-start me-3"
       onClick={handleDownload}
       title={`Download ${checksumType} checksums`}
     >

--- a/frontend/src/app/components/DropdownButton.tsx
+++ b/frontend/src/app/components/DropdownButton.tsx
@@ -1,0 +1,64 @@
+type DropdownItem = {
+  label: string;
+  onClick?: () => void;
+  disabled?: boolean;
+  modalTarget?: string;
+};
+
+type DropdownButtonProps = {
+  label: string;
+  items: DropdownItem[];
+  disabled?: boolean;
+};
+
+/**
+ * Reusable Bootstrap dropdown button.
+ *
+ * Use `label` for the main button text and `items` for the dropdown options.
+ * Each item can either trigger an `onClick` function or open a Bootstrap modal
+ * by passing `modalTarget`, for example "#cliModal".
+ */
+export default function DropdownButton({
+  label,
+  items,
+  disabled = false,
+}: DropdownButtonProps) {
+  return (
+    <div className="dropdown">
+      <button
+        className="btn btn-outline-primary dropdown-toggle me-3"
+        type="button"
+        data-bs-toggle="dropdown"
+        aria-expanded="false"
+        disabled={disabled}
+      >
+        {label}
+      </button>
+
+      <ul className="dropdown-menu">
+        {items.map((item) => {
+          const modalAttributes = item.modalTarget
+            ? {
+                "data-bs-toggle": "modal",
+                "data-bs-target": item.modalTarget,
+              }
+            : {};
+
+          return (
+            <li key={item.label}>
+              <button
+                type="button"
+                className="dropdown-item"
+                onClick={item.onClick}
+                disabled={item.disabled}
+                {...modalAttributes}
+              >
+                {item.label}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/app/components/ModalDialog.tsx
+++ b/frontend/src/app/components/ModalDialog.tsx
@@ -32,7 +32,7 @@ export function ModalDialog({
       <div
         className="modal fade"
         id={id}
-        tabIndex="-1"
+        tabIndex={-1}
         aria-labelledby={titleId}
         aria-hidden="true"
       >

--- a/frontend/src/app/components/ModalDialog.tsx
+++ b/frontend/src/app/components/ModalDialog.tsx
@@ -8,6 +8,16 @@ type ModalProps = {
   iconClass: string;
   actionButtonLabel: string;
 };
+/**
+ * Reusable Bootstrap modal dialog.
+ *
+ * Use `id` as the modal target, for example `#cliModal` from a button's
+ * `data-bs-target`. The `title` is rendered in the modal header, `body`
+ * is rendered in the modal body.
+ *
+ * The modal contains a close button and for the action button use action property.
+ * The iconClass and actionButtonLabel add icon and label for the action button.
+ */
 export function ModalDialog({
   id,
   title,

--- a/frontend/src/app/components/ModalDialog.tsx
+++ b/frontend/src/app/components/ModalDialog.tsx
@@ -1,0 +1,55 @@
+type ModalProps = {
+  id: string;
+  title: string;
+  body: string;
+  action: () => void;
+  iconClass: string;
+  actionButtonLabel: string;
+};
+export function ModalDialog({ id, title, body, action, iconClass, actionButtonLabel }: ModalProps) {
+  const titleId = `${id}Label`;
+  return (
+    <>
+      <div
+        className="modal fade"
+        id={id}
+        tabIndex="-1"
+        aria-labelledby={titleId}
+        aria-hidden="true"
+      >
+        <div className="modal-dialog">
+          <div className="modal-content">
+            <div className="modal-header">
+              <h1 className="modal-title fs-5" id={titleId}>
+                {title}
+              </h1>
+              <button
+                type="button"
+                className="btn-close"
+                data-bs-dismiss="modal"
+                aria-label="Close"
+              ></button>
+            </div>
+            <div className="modal-body">{body}</div>
+            <div className="modal-footer">
+              <button
+                type="button"
+                className="btn btn-secondary"
+                data-bs-dismiss="modal"
+              >
+                Close
+              </button>
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={action}
+              >
+                <i className={`bi ${iconClass} me-1`}></i>{actionButtonLabel}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/app/components/ModalDialog.tsx
+++ b/frontend/src/app/components/ModalDialog.tsx
@@ -1,12 +1,21 @@
+import { ReactNode } from "react";
+
 type ModalProps = {
   id: string;
   title: string;
-  body: string;
+  body: ReactNode;
   action: () => void;
   iconClass: string;
   actionButtonLabel: string;
 };
-export function ModalDialog({ id, title, body, action, iconClass, actionButtonLabel }: ModalProps) {
+export function ModalDialog({
+  id,
+  title,
+  body,
+  action,
+  iconClass,
+  actionButtonLabel,
+}: ModalProps) {
   const titleId = `${id}Label`;
   return (
     <>
@@ -44,7 +53,8 @@ export function ModalDialog({ id, title, body, action, iconClass, actionButtonLa
                 className="btn btn-primary"
                 onClick={action}
               >
-                <i className={`bi ${iconClass} me-1`}></i>{actionButtonLabel}
+                <i className={`bi ${iconClass} me-1`}></i>
+                {actionButtonLabel}
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Related issue

This PR closes #119.

The issue is about adding a copy command function to download a whole dataset with sda-cli.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## List of changes made

- Added the "download via sda-cli command" under a Download options dropdown
- Made the dropdown a separate component
- created a modal dialog component that can be re-used
- used the Bootstrap utilities for dropdown and modal

## Screenshot of the fix

The dataset details:

<img width="891" height="392" alt="Screenshot from 2026-06-24 16-31-30" src="https://github.com/user-attachments/assets/78c64449-0b95-4a60-8b92-b9c92ed35580" />
<img width="891" height="392" alt="Screenshot from 2026-06-24 16-31-40" src="https://github.com/user-attachments/assets/08f2eae9-1014-4bb1-b923-1d0aec65cb04" />

The modal:
<img width="1072" height="784" alt="image" src="https://github.com/user-attachments/assets/9733280c-e374-4f45-af10-7441511952ad" />

## Further comments

At the moment the command to copy has several placeholders such as configuration_file, public-key-file, download-service-url, and outdir. There could be options there that could be pre-filled that I am not aware of but this would be an easy fix in a follow up issue. The same regarding the instructions given in the modal body.

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any
- [x] All Acceptance Criteria (AC) Fulfilled and checked in the Related issue
