### PR TITLE
Add Logout logic

### DIFF
--- a/frontend/src/app/actions/logout.test.ts
+++ b/frontend/src/app/actions/logout.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { redirect, RedirectType } from "next/navigation";
+import { clearSession } from "../lib/session";
+import { logout } from "./logout";
+
+vi.mock("../lib/session", () => ({
+  clearSession: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  RedirectType: {
+    replace: "replace",
+  },
+  redirect: vi.fn(() => {
+    throw new Error("NEXT_REDIRECT");
+  }),
+}));
+
+describe("logout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("clears the session and redirects to the home page", async () => {
+    await expect(logout()).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(clearSession).toHaveBeenCalledOnce();
+    expect(redirect).toHaveBeenCalledOnce();
+    expect(redirect).toHaveBeenCalledWith("/", RedirectType.replace);
+  });
+});

--- a/frontend/src/app/actions/logout.ts
+++ b/frontend/src/app/actions/logout.ts
@@ -1,0 +1,9 @@
+"use server";
+
+import { redirect, RedirectType } from "next/navigation";
+import { clearSession } from "../lib/session";
+
+export async function logout() {
+  await clearSession();
+  redirect("/", RedirectType.replace);
+}

--- a/frontend/src/app/components/Header.tsx
+++ b/frontend/src/app/components/Header.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
+import { logout } from "../actions/logout";
 
 export function Header() {
   const [isNavCollapsed, setIsNavCollapsed] = useState(true);
@@ -13,7 +14,6 @@ export function Header() {
   const navLinks = [
     { href: "/datasets", label: "Datasets" },
     { href: "/userinfo", label: "Your profile" },
-    { href: "/logout", label: "Logout" },
   ];
 
   const isHome = pathname === "/";
@@ -67,6 +67,18 @@ export function Header() {
                   </li>
                 );
               })}
+
+              <li className="nav-item">
+                <form action={logout}>
+                  <button
+                    type="submit"
+                    className="nav-link px-3 border-0 bg-transparent w-100 text-center text-md-start"
+                    onClick={() => setIsNavCollapsed(true)}
+                  >
+                    Logout
+                  </button>
+                </form>
+              </li>
             </ul>
           </div>
         </div>

--- a/frontend/src/app/lib/SessionManager.test.ts
+++ b/frontend/src/app/lib/SessionManager.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cookies } from "next/headers";
+import { createSDADSessionManager } from "./SessionManager";
+
+// We need to mock the server only import for the test to work
+vi.mock("server-only", () => ({}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(),
+}));
+
+describe("SessionManager.clearSession", () => {
+  const deleteCookie = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(cookies).mockResolvedValue({
+      delete: deleteCookie,
+    } as never);
+  });
+
+  it("deletes the session cookie", async () => {
+    const sessionManager = createSDADSessionManager("AA");
+
+    await sessionManager.clearSession();
+
+    expect(cookies).toHaveBeenCalledOnce();
+    expect(deleteCookie).toHaveBeenCalledOnce();
+    expect(deleteCookie).toHaveBeenCalledWith("sdad-session");
+  });
+});

--- a/frontend/src/app/lib/SessionManager.ts
+++ b/frontend/src/app/lib/SessionManager.ts
@@ -79,6 +79,11 @@ class SessionManager<ST extends Record<string, unknown>> {
       return null;
     }
   }
+
+  async clearSession(): Promise<void> {
+    const cookieStore = await cookies();
+    cookieStore.delete(this._sessionId);
+  }
 }
 
 export const getSessionManager: () => Promise<SessionManager<SessionData>> =

--- a/frontend/src/app/lib/session.test.ts
+++ b/frontend/src/app/lib/session.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getSessionManager } from "./SessionManager";
+import { clearSession } from "./session";
+
+// We need to mock the server only import for the test to work
+vi.mock("server-only", () => ({}));
+
+vi.mock("./SessionManager", () => ({
+  getSessionManager: vi.fn(),
+}));
+
+describe("clearSession", () => {
+  const managerClearSession = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(getSessionManager).mockResolvedValue({
+      clearSession: managerClearSession,
+    } as never);
+  });
+
+  it("gets the session manager and clears the session", async () => {
+    await clearSession();
+
+    expect(getSessionManager).toHaveBeenCalledOnce();
+    expect(managerClearSession).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/app/lib/session.ts
+++ b/frontend/src/app/lib/session.ts
@@ -31,6 +31,11 @@ export async function getSession(): Promise<SessionData | null> {
   return await sessionManager.getSession();
 }
 
+export async function clearSession(): Promise<void> {
+  const sessionManager = await getSessionManager();
+  await sessionManager.clearSession();
+}
+
 export async function getClaims(token: string) {
   const claims = await jose.decodeJwt(token);
   return claims;


### PR DESCRIPTION
## Related issue(s) and PR(s)

This PR closes #11 to add the log out functionality.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## List of changes made

- New log out action with [redirect ](https://nextjs.org/docs/app/api-reference/functions/redirect) to the log in page using replace to prevent user to go back with the browser buttons
- Functions in session and session manager to clear the session cookie
- Tests to verify the functionality

## Testing

Use the log out  button from the menu.

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any
- [x] All Acceptance Criteria (AC) Fulfilled and checked in the Related issue
