### PR TITLE
118 batch download using file system access

### DIFF
--- a/frontend/src/app/components/BatchDownloadActions.tsx
+++ b/frontend/src/app/components/BatchDownloadActions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { MAX_TAR_SELECTION } from "@/app/lib/constants";
+import { TarBatchDownloadActions } from "@/app/components/TarBatchDownloadActions";
 
 type BatchDownloadActionsProps = {
   selectedFileIds: Set<string>;
@@ -13,51 +13,11 @@ export function BatchDownloadActions({
   datasetId,
   canDownload = true,
 }: BatchDownloadActionsProps) {
-  const selectedCount = selectedFileIds.size;
-  const tooMany = selectedCount > MAX_TAR_SELECTION;
-  const enabled = canDownload && selectedCount > 0 && !tooMany;
-
-  const tarUrl =
-    `/api/datasets/${encodeURIComponent(datasetId)}/download.tar` +
-    `?fileIds=${Array.from(selectedFileIds).map(encodeURIComponent).join(",")}`;
-
-  const reason = !canDownload
-    ? "Upload your Crypt4GH public key on the profile page to enable downloads."
-    : selectedCount === 0
-      ? null // not really an error — don't nag the user
-      : tooMany
-        ? `Selection exceeds the ${MAX_TAR_SELECTION}-file cap.`
-        : null;
-
   return (
-    <div className="d-flex flex-column align-items-start gap-1">
-      {enabled ? (
-        <a
-          className="btn btn-outline-primary"
-          href={tarUrl}
-          download
-          rel="noopener"
-        >
-          Download selected as TAR
-        </a>
-      ) : (
-        <button
-          type="button"
-          className="btn btn-outline-primary"
-          disabled
-          aria-describedby={reason ? "batch-tar-reason" : undefined}
-        >
-          Download selected as TAR
-        </button>
-      )}
-      {reason && (
-        <small
-          id="batch-tar-reason"
-          className={`text-${tooMany ? "warning" : "muted"}`}
-        >
-          {reason}
-        </small>
-      )}
-    </div>
+    <TarBatchDownloadActions
+      selectedFileIds={selectedFileIds}
+      datasetId={datasetId}
+      canDownload={canDownload}
+    />
   );
 }

--- a/frontend/src/app/components/BatchDownloadActions.tsx
+++ b/frontend/src/app/components/BatchDownloadActions.tsx
@@ -1,18 +1,51 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
+import type { DatasetFile } from "@/app/actions/datasets";
 import { TarBatchDownloadActions } from "@/app/components/TarBatchDownloadActions";
+import { FileSystemAccessBatchDownloadActions } from "@/app/components/FileSystemAccessBatchDownloadActions";
 
 type BatchDownloadActionsProps = {
+  files: Pick<DatasetFile, "fileId" | "filePath">[];
   selectedFileIds: Set<string>;
   datasetId: string;
   canDownload?: boolean;
 };
 
+function useFileSystemAccessSupported() {
+  const [supported, setSupported] = useState(false);
+
+  useEffect(() => {
+    setSupported(
+      "showDirectoryPicker" in window &&
+        typeof window.showDirectoryPicker === "function",
+    );
+  }, []);
+
+  return supported;
+}
+
 export function BatchDownloadActions({
+  files,
   selectedFileIds,
   datasetId,
   canDownload = true,
 }: BatchDownloadActionsProps) {
+  const supportsFileSystemAccess = useFileSystemAccessSupported();
+
+  const selectedFiles = useMemo(() => {
+    return files.filter((file) => selectedFileIds.has(file.fileId));
+  }, [files, selectedFileIds]);
+
+  if (supportsFileSystemAccess) {
+    return (
+      <FileSystemAccessBatchDownloadActions
+        selectedFiles={selectedFiles}
+        canDownload={canDownload}
+      />
+    );
+  }
+
   return (
     <TarBatchDownloadActions
       selectedFileIds={selectedFileIds}

--- a/frontend/src/app/components/BatchDownloadActions.tsx
+++ b/frontend/src/app/components/BatchDownloadActions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useSyncExternalStore } from "react";
 import type { DatasetFile } from "@/app/actions/datasets";
 import { TarBatchDownloadActions } from "@/app/components/TarBatchDownloadActions";
 import { FileSystemAccessBatchDownloadActions } from "@/app/components/FileSystemAccessBatchDownloadActions";
@@ -12,17 +12,30 @@ type BatchDownloadActionsProps = {
   canDownload?: boolean;
 };
 
+type WindowWithDirectoryPicker = Window & {
+  showDirectoryPicker?: unknown;
+};
+
+function subscribe() {
+  return function unsubscribe() {
+    // No clean up needed.
+  };
+}
+
+function getSnapshot() {
+  return (
+    typeof window !== "undefined" &&
+    typeof (window as WindowWithDirectoryPicker).showDirectoryPicker ===
+      "function"
+  );
+}
+
+function getServerSnapshot() {
+  return false;
+}
+
 function useFileSystemAccessSupported() {
-  const [supported, setSupported] = useState(false);
-
-  useEffect(() => {
-    setSupported(
-      "showDirectoryPicker" in window &&
-        typeof window.showDirectoryPicker === "function",
-    );
-  }, []);
-
-  return supported;
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }
 
 export function BatchDownloadActions({

--- a/frontend/src/app/components/DatasetFiles.tsx
+++ b/frontend/src/app/components/DatasetFiles.tsx
@@ -203,6 +203,7 @@ export default function DatasetFiles({
           {selectedFileIds.size === 1 ? "file selected" : "files selected"}
         </div>
         <BatchDownloadActions
+          files={files}
           selectedFileIds={selectedFileIds}
           datasetId={datasetId}
           canDownload={canDownload}

--- a/frontend/src/app/components/FileSystemAccessBatchDownloadActions.tsx
+++ b/frontend/src/app/components/FileSystemAccessBatchDownloadActions.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+import { useRef, useState } from "react";
+import type { DatasetFile } from "@/app/actions/datasets";
+
+// Controls the number of active concurrent downloads.
+const FILE_SYSTEM_BATCH_CONCURRENCY = 2;
+
+// We need fileId for /api/files/:fileId and filePath to
+// preserve the dataset folder structure.
+type FileSystemAccessBatchDownloadActionsProps = {
+  selectedFiles: Pick<DatasetFile, "fileId" | "filePath">[];
+  canDownload: boolean;
+};
+
+export function FileSystemAccessBatchDownloadActions({
+  selectedFiles,
+  canDownload,
+}: FileSystemAccessBatchDownloadActionsProps) {
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [completedCount, setCompletedCount] = useState(0);
+  const [activeCount, setActiveCount] = useState(0);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const selectedCount = selectedFiles.length;
+  const enabled = canDownload && selectedCount > 0 && !isDownloading;
+
+  async function startDownload() {
+    if (!enabled) return;
+
+    // Check that the browser supports the File System Access API.
+    // Here we check for the existence of `showDirectoryPicker` in the window object and ensure it's a function.
+    // Checking if `window` contains `showDirectoryPicker` before asserting its type is a workaround to the fact that
+    // our current TypeScript version does not include this File System Access API method in its type definitions.
+    if (
+      !("showDirectoryPicker" in window) ||
+      typeof window.showDirectoryPicker !== "function"
+    ) {
+      setErrorMessage("Folder downloads are not supported in this browser.");
+      return;
+    }
+
+    setErrorMessage(null);
+    setCompletedCount(0);
+    setActiveCount(0);
+    setIsDownloading(true);
+
+    // An AbortController instance is shared by all active and future downloads in the
+    // batch so that calling abort() cancels active fetches and prevents new workers
+    // from starting more files.
+    const abortController = new AbortController();
+    abortControllerRef.current = abortController;
+
+    try {
+      const directoryHandle = (await window.showDirectoryPicker({
+        mode: "readwrite",
+      })) as FileSystemDirectoryHandle;
+
+      await runWithConcurrency(
+        selectedFiles,
+        FILE_SYSTEM_BATCH_CONCURRENCY,
+        abortController.signal,
+        async (file) => {
+          setActiveCount((count) => count + 1);
+
+          try {
+            await downloadFileToDirectory(
+              file,
+              directoryHandle,
+              abortController.signal,
+            );
+
+            setCompletedCount((count) => count + 1);
+          } catch (error) {
+            // A later PR could instead collect per-file failures and continue so that we can resume the download.
+            abortController.abort();
+            throw error;
+          } finally {
+            // Avoid negative counts in case of race condition situations.
+            setActiveCount((count) => Math.max(count - 1, 0));
+          }
+        },
+      );
+    } catch (error) {
+      if ((error as { name?: string }).name === "AbortError") {
+        setErrorMessage("Download cancelled.");
+      } else {
+        const message =
+          error instanceof Error ? error.message : "Download failed.";
+        setErrorMessage(message);
+      }
+    } finally {
+      setIsDownloading(false);
+      abortControllerRef.current = null;
+    }
+  }
+
+  function cancelDownload() {
+    abortControllerRef.current?.abort();
+  }
+
+  const reason = !canDownload
+    ? "Upload your Crypt4GH public key on the profile page to enable downloads."
+    : selectedCount === 0
+      ? null
+      : null;
+
+  return (
+    <div className="d-flex flex-column align-items-start gap-1">
+      <div className="d-flex gap-2">
+        <button
+          type="button"
+          className="btn btn-outline-primary"
+          onClick={startDownload}
+          disabled={!enabled}
+          aria-describedby={reason ? "batch-folder-download-reason" : undefined}
+        >
+          {isDownloading
+            ? "Downloading selected files..."
+            : "Download selected files to folder"}
+        </button>
+
+        {isDownloading && (
+          <button
+            type="button"
+            className="btn btn-outline-danger"
+            onClick={cancelDownload}
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+
+      {reason && (
+        <small id="batch-folder-download-reason" className="text-muted">
+          {reason}
+        </small>
+      )}
+
+      {isDownloading && (
+        <small className="text-muted">
+          Completed <strong>{completedCount}</strong> of{" "}
+          <strong>{selectedCount}</strong>. Active downloads:{" "}
+          <strong>{activeCount}</strong>.
+        </small>
+      )}
+
+      {errorMessage && <small className="text-danger">{errorMessage}</small>}
+    </div>
+  );
+}
+
+// Start concurrent workers to download files in parallel. All workers share the same AbortSignal
+// so that a single failure cancels the entire batch.
+async function runWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  signal: AbortSignal,
+  worker: (item: T, index: number) => Promise<void>,
+) {
+  let nextIndex = 0;
+
+  const workers = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    async () => {
+      while (!signal.aborted) {
+        const index = nextIndex++;
+
+        if (index >= items.length) {
+          return;
+        }
+
+        await worker(items[index], index);
+      }
+    },
+  );
+
+  await Promise.all(workers);
+}
+
+// Download one dataset file and write it into the selected folder. This reuses the
+// existing single-file proxy endpoint: /api/files/:fileId?name=:filePath.
+async function downloadFileToDirectory(
+  file: Pick<DatasetFile, "fileId" | "filePath">,
+  rootDirectoryHandle: FileSystemDirectoryHandle,
+  signal: AbortSignal,
+) {
+  const url =
+    `/api/files/${encodeURIComponent(file.fileId)}` +
+    `?name=${encodeURIComponent(file.filePath)}`;
+  const response = await fetch(url, {
+    credentials: "same-origin",
+    signal,
+  });
+
+  if (!response.ok) {
+    let message = `Failed to download ${file.filePath}: ${response.status}`;
+
+    try {
+      const body = await response.json();
+
+      if (typeof body?.error === "string") {
+        message = body.error;
+      }
+    } catch {}
+
+    throw new Error(message);
+  }
+
+  // The individual-file endpoint should return application/octet-stream for successful
+  // file downloads, so reject anything else. This helps avoid cases where e.g. the session has
+  // expired and the server returns an HTML login page instead of the file.
+  const contentType = response.headers.get("content-type") || "";
+
+  if (!contentType.includes("application/octet-stream")) {
+    throw new Error(
+      `Unexpected response while downloading ${file.filePath}. Your session may have expired.`,
+    );
+  }
+
+  if (!response.body) {
+    throw new Error(`No response body for ${file.filePath}.`);
+  }
+
+  const fileHandle = await getFileHandleForDatasetPath(
+    rootDirectoryHandle,
+    file.filePath,
+  );
+
+  // Here we overwrite any existing file with the same path until resume support is implemented.
+  const writable = await fileHandle.createWritable();
+  const reader = response.body.getReader();
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+
+      if (done) break;
+
+      if (value) {
+        await writable.write(value);
+      }
+    }
+
+    await writable.close();
+  } catch (error) {
+    try {
+      await reader.cancel();
+    } catch {}
+
+    try {
+      await writable.abort(error);
+    } catch {}
+
+    throw error;
+  }
+}
+
+// Resolve a dataset file path to a File System Access file handle.
+// filePath = "folder/subfolder/sample.cram.c4gh" becomes:
+// <chosen-folder>/folder/subfolder/sample.cram.c4gh
+async function getFileHandleForDatasetPath(
+  rootDirectoryHandle: FileSystemDirectoryHandle,
+  filePath: string,
+): Promise<FileSystemFileHandle> {
+  const pathParts = filePath
+    .split(/[\\/]+/)
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .filter((part) => part !== "." && part !== "..")
+    .map(sanitizePathSegment);
+
+  const filename = pathParts.pop() || "download.c4gh";
+
+  let currentDirectory = rootDirectoryHandle;
+
+  for (const directoryName of pathParts) {
+    currentDirectory = await currentDirectory.getDirectoryHandle(
+      directoryName,
+      {
+        create: true,
+      },
+    );
+  }
+
+  return currentDirectory.getFileHandle(filename, {
+    create: true,
+  });
+}
+
+function sanitizePathSegment(segment: string): string {
+  const sanitized = segment
+    .replace(/[<>:"|?*\x00-\x1F]/g, "_")
+    .replace(/^\.+$/, "_")
+    .slice(0, 255);
+
+  return sanitized || "_";
+}

--- a/frontend/src/app/components/TarBatchDownloadActions.tsx
+++ b/frontend/src/app/components/TarBatchDownloadActions.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { MAX_TAR_SELECTION } from "@/app/lib/constants";
+
+type TarBatchDownloadActionsProps = {
+  selectedFileIds: Set<string>;
+  datasetId: string;
+  canDownload?: boolean;
+};
+
+export function TarBatchDownloadActions({
+  selectedFileIds,
+  datasetId,
+  canDownload = true,
+}: TarBatchDownloadActionsProps) {
+  const selectedCount = selectedFileIds.size;
+  const tooMany = selectedCount > MAX_TAR_SELECTION;
+  const enabled = canDownload && selectedCount > 0 && !tooMany;
+
+  const tarUrl =
+    `/api/datasets/${encodeURIComponent(datasetId)}/download.tar` +
+    `?fileIds=${Array.from(selectedFileIds).map(encodeURIComponent).join(",")}`;
+
+  const reason = !canDownload
+    ? "Upload your Crypt4GH public key on the profile page to enable downloads."
+    : selectedCount === 0
+      ? null // not really an error — don't nag the user
+      : tooMany
+        ? `Selection exceeds the ${MAX_TAR_SELECTION}-file cap.`
+        : null;
+
+  return (
+    <div className="d-flex flex-column align-items-start gap-1">
+      {enabled ? (
+        <a
+          className="btn btn-outline-primary"
+          href={tarUrl}
+          download
+          rel="noopener"
+        >
+          Download selected as TAR
+        </a>
+      ) : (
+        <button
+          type="button"
+          className="btn btn-outline-primary"
+          disabled
+          aria-describedby={reason ? "batch-tar-reason" : undefined}
+        >
+          Download selected as TAR
+        </button>
+      )}
+      {reason && (
+        <small
+          id="batch-tar-reason"
+          className={`text-${tooMany ? "warning" : "muted"}`}
+        >
+          {reason}
+        </small>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Related issue(s) and PR(s)

This PR partially closes #118 and leaves the resume implementation for the follow-up #149.

It adds a Chromium-specific batch download path using the File System Access (FSA) API.
Browsers that support extended features of the FSA API, now download selected files individually through the existing /api/files/:fileId endpoint and write them directly into a user-selected local folder. Dataset-relative file paths are preserved, so file prefixes are recreated as local directories.
Browsers without File System Access API support continue to use the existing TAR bundle batch download flow unchanged.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## List of changes made

- Refactored the existing TAR batch download logic into TarBatchDownloadActions.
- Added FileSystemAccessBatchDownloadActions for supported browsers.
- The BatchDownloadActions is now a wrapper of the above two actions. It detects whether the browser support FSA downloads:
   - if yes, it defaults to that.
   - if no it falls back to using the TAR bundle method.

- FSA downloads are limited to 2 concurrent active downloads (hardcoded choice).
- Added cancellation support for active FSA batch downloads.

## Testing

- Instructions on how to test

Deploy the two stacks as usual. Log in, submit a pub c4gh key and try to batch download files of a dataset:

- Use chromium/chrome/brave: you should see the `Download selected files to folder` button and you can try out the new FSA functionality.

- Use a different browser (firefox/safari): you should see the `Download selected as TAR` button instead and this should work as before.

I have only tested with `firefox` and `chromium`. It would be nice if someone could try with Safari/Edge.

## Further comments

Resume support for File System Access downloads is not included in this PR and can be added separately. The existing /api/files/:fileId endpoint already supports range requests, so the new FSA path can be extended with resumable download behavior in a follow-up.

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings

- [x] **Follow-up Backlog Items Created (if applicable):**
  - Necessary follow-up tasks have been identified and added to the backlog.
  Opened follow-up issue #149  for implementing resumable downloads.