### PR TITLE
Add config information to README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ This can be done by using the following command:
 openssl rand -base64 32 > secrets/frontend-token-secret.txt
 ```
 
+In the `secrets` folder you also need to create the files
+- `frontend-next-auth-secret.txt`
+- `frontend-oicd-client-id`
+- `frontend-oicd-client-secret`
+
 The options available in the config file can be described as follows:
 | Option | Type | Description |
 | :----- | :--- | :---------- |

--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -76,6 +76,22 @@ to
 userinfo-url: "http://localhost:8800/oidc/userinfo"
 ```
 
+In the folder `aai-mock/clients` add a file `sdad.yml` containing the following configurations:
+
+```
+client-name: "sdad"
+client-id: "<your-client-id>"
+client-secret: "<your-client-secret>"
+redirect-uris: ["http://localhost:3002/api/auth/callback/lsaai-oidc"]
+token-endpoint-auth-method: "client_secret_basic"
+scope: ["openid", "profile", "email", "ga4gh_passport_v1", "eduperson_entitlement"]
+grant-types: ["authorization_code"]
+post-logout-redirect-uris: ["http://localhost:3002/api/auth/login"]
+access-token-validity-seconds: 2592000
+```
+
+When running the frontend the values for `client-id` and `client-secret` need to correspond with the values in your files `../secrets/frontend-oicd-client-id.txt` and `../secrets/frontend-oicd-client-secret.txt`.
+
 Finally run:
 
 ``` bash


### PR DESCRIPTION
## Related issue(s) and PR(s)

This PR doesn't have a related issue.

## Bug description

There was information missing on how to configure the lsaai-mock to run the current dev environment.

## Fix implemented

- addition to the dev-tools README 
- addition to the main README

Both additions are based on the information in #100 , a PR that was merged in June 2026.

## Further comments

I found it slightly difficult to decide where to place all the information needed. If you have a different suggestion that you think would make more sense, please let me know.
